### PR TITLE
MoPub Adapter supports MoPub 5.8.0 release

### DIFF
--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -16,6 +16,8 @@
 
 // If you need to play ads with vungle options, you may modify playVungleAdFromRootViewController and create an options dictionary and call the playAd:withOptions: method on the vungle SDK.
 
+static const CGFloat kVGNMoPubMRECWidthFor280Height = 336.0f;
+
 @interface VungleBannerCustomEvent () <VungleRouterDelegate>
 
 @property (nonatomic, copy) NSString *placementId;
@@ -32,6 +34,12 @@
 - (void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.options = nil;
+    
+    // Since MoPub supports two sizes MREC Ad (300 x 250 and 336 x 280)),
+    // if they pass 336 x 280 size, we will convert it to 300 x 250 size
+    if (CGSizeEqualToSize(size, CGSizeMake(kVGNMoPubMRECWidthFor280Height, kMPPresetMaxAdSize280Height.height))) {
+        size = kVGNMRECSize;
+    }
     self.bannerSize = size;
     self.bannerInfo = info;
     self.isAdCached = NO;
@@ -90,7 +98,7 @@
         self.options = options.count ? options : nil;
 
         // generate view with size
-        UIView *mrecAdView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, MOPUB_MEDIUM_RECT_SIZE.width, MOPUB_MEDIUM_RECT_SIZE.height)];
+        UIView *mrecAdView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.bannerSize.width, self.bannerSize.height)];
 
         // router call to add ad view to view - should return the updated view.
         mrecAdView = [[VungleRouter sharedRouter] renderBannerAdInView:mrecAdView options:self.options forPlacementID:self.placementId];

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -20,6 +20,8 @@ extern NSString *const kVungleSDKMinSpaceForInit;
 extern NSString *const kVungleSDKMinSpaceForAdRequest;
 extern NSString *const kVungleSDKMinSpaceForAssetLoad;
 
+extern const CGSize kVGNMRECSize;
+
 @protocol VungleRouterDelegate;
 @class VungleInstanceMediationSettings;
 

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -32,6 +32,8 @@ NSString *const kVungleSDKMinSpaceForAssetLoad = @"vungleMinimumFileSystemSizeFo
 static NSString *const kVungleBannerDelegateKey = @"bannerDelegate";
 static NSString *const kVungleBannerDelegateStateKey = @"bannerState";
 
+const CGSize kVGNMRECSize = {.width = 300.0f, .height = 250.0f};
+
 typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     SDKInitializeStateNotInitialized,
     SDKInitializeStateInitializing,
@@ -213,7 +215,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
         return;
     }
 
-    if ([self validateInfoData:info] && CGSizeEqualToSize(size, MOPUB_MEDIUM_RECT_SIZE)) {
+    if ([self validateInfoData:info] && CGSizeEqualToSize(size, kVGNMRECSize)) {
         self.bannerPlacementID = [info objectForKey:kVunglePlacementIdKey];
 
         if (self.sdkInitializeState == SDKInitializeStateNotInitialized) {


### PR DESCRIPTION
For MoPub side comments,  to update the banner ad size code similar to Android `VungleBanner` changes to make it compatible with 5.8 SDK - https://github.com/mopub/mopub-android-mediation/blob/d2be76d040c5bd026839bf8a0c8d8ebf506e206b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java#L139, I made some updates.
Since MoPub supports two sizes MREC Ad (300 x 250 and 336 x 280)), if they pass 336 x 280 size, we will convert it to 300 x 250 size.