### PR TITLE
Fix first fresh always failed issue

### DIFF
--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -63,6 +63,11 @@ static const CGFloat kVGNMoPubMRECWidthFor280Height = 336.0f;
 //    [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId];
 }
 
+// Secret MoPub API to allow us to detach the custom event from (shared instance) routers synchronously
+- (void) invalidate{
+     [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId];
+}
+
 #pragma mark - VungleRouterDelegate Methods
 
 - (void)vungleAdDidLoad

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -373,13 +373,6 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
             if ((BannerRouterDelegateState)[[self.bannerDelegates[i] valueForKey:kVungleBannerDelegateStateKey] intValue] == BannerRouterDelegateStatePlaying) {
                 [[VungleSDK sharedSDK] finishedDisplayingAd];
                 [self.bannerDelegates[i] setObject:[NSNumber numberWithInt:BannerRouterDelegateStateClosing] forKey:kVungleBannerDelegateStateKey];
-                // Set MREC/Banner placement to nil after finishing playing MREC/Banner ad,
-                // so adapter can load next MREC/Banner with different placement ID.
-                if ([self.mrecPlacementID isEqualToString:placementID]) {
-                    self.mrecPlacementID = nil;
-                } else if ([self.bannerPlacementID isEqualToString:placementID]) {
-                    self.bannerPlacementID = nil;
-                }
             }
         }
     }
@@ -613,6 +606,14 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 
     if (targetDelegate) {
         [targetDelegate vungleAdDidDisappear];
+    }
+    
+    // Set MREC/Banner placement to nil after finishing playing MREC/Banner ad,
+    // so adapter can load next MREC/Banner with different placement ID.
+    if ([placementID isEqualToString:self.mrecPlacementID]){
+        self.mrecPlacementID = nil;
+    } else if ([placementID isEqualToString:self.bannerPlacementID]) {
+        self.bannerPlacementID = nil;
     }
 }
 


### PR DESCRIPTION
For MoPub Adapter QA TestApp, when fresh the banner ad at first time, we always get failed.
Another issue is we couldn't load another banner ad after we finishing displaying a banner ad.
To fix these two issues, we need to move below code in "completeBannerAdViewForPlacementID:" method to "vungleDidCloseAdWithViewInfo:placementID:" delegate method which would be called after calling "finishedDisplayingAd" method,

 if ([self.mrecPlacementID isEqualToString:placementID]) {
                    self.mrecPlacementID = nil;
                } else if ([self.bannerPlacementID isEqualToString:placementID]) {
                    self.bannerPlacementID = nil;
                }
