### PR TITLE
Revert vungeAdWasTapped in Mopub 6.4.x adapter

### DIFF
--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"6.4.2.1";
+    return @"6.4.3.0";
 }
 
 - (NSString *)biddingToken {

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -14,7 +14,7 @@
 #endif
 #import "VungleInstanceMediationSettings.h"
 
-static NSString *const VungleAdapterVersion = @"6.4.2.1";
+static NSString *const VungleAdapterVersion = @"6.4.3.0";
 
 NSString *const kVungleAppIdKey = @"appId";
 NSString *const kVunglePlacementIdKey = @"pid";
@@ -536,6 +536,10 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
     }
 
     if(targetDelegate) {
+        if ([info.didDownload isEqual:@YES]) {
+            [targetDelegate vungleAdWasTapped];
+        }
+
         if ([info.completedView boolValue] && [targetDelegate respondsToSelector:@selector(vungleAdShouldRewardUser)]) {
             [targetDelegate vungleAdShouldRewardUser];
         }


### PR DESCRIPTION
1、Remove below call has led to some publishers complaining that their clicks are not being counted .

if ([info.didDownload isEqual:@YES]) {
            [targetDelegate vungleAdWasTapped];
        }

 So we need to revert the changes made related to vungeAdWasTapped .

2、Update the adapter version number to 6.4.3.0.