### PR TITLE
[IOS-2524]Pass options issue for interstitial fix

### DIFF
--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -53,14 +53,6 @@
         
         NSMutableDictionary *options = [NSMutableDictionary dictionary];
         
-        // VunglePlayAdOptionKeyUser
-        if ([self.localExtras objectForKey:kVungleUserId] != nil) {
-            NSString *userID = [self.localExtras objectForKey:kVungleUserId];
-            if (userID.length > 0) {
-                options[VunglePlayAdOptionKeyUser] = userID;
-            }
-        }
-        
         // Ordinal
         if ([self.localExtras objectForKey:kVungleOrdinal] != nil) {
             NSNumber *ordinalPlaceholder = [NSNumber numberWithLongLong:[[self.localExtras objectForKey:kVungleOrdinal] longLongValue]];
@@ -76,6 +68,24 @@
             if (flexDismissTime > 0) {
                 options[VunglePlayAdOptionKeyFlexViewAutoDismissSeconds] = @(flexDismissTime);
             }
+        }
+
+        // Muted
+        if ([self.localExtras objectForKey:kVungleStartMuted] != nil) {
+            BOOL startMutedPlaceholder = [[self.localExtras objectForKey:kVungleStartMuted] boolValue];
+            options[VunglePlayAdOptionKeyStartMuted] = @(startMutedPlaceholder);
+        }
+
+        // Orientations
+        if ([self.localExtras objectForKey:kVungleSupportedOrientations] != nil) {
+            int appOrientation = [[self.localExtras objectForKey:kVungleSupportedOrientations] intValue];
+            NSNumber *orientations = @(UIInterfaceOrientationMaskAll);
+            if (appOrientation == 1) {
+                orientations = @(UIInterfaceOrientationMaskLandscape);
+            } else if (appOrientation == 2) {
+                orientations = @(UIInterfaceOrientationMaskPortrait);
+            }
+            options[VunglePlayAdOptionKeyOrientations] = orientations;
         }
 
         self.options = options.count ? options : nil;

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -15,6 +15,7 @@ extern NSString *const kVungleFlexViewAutoDismissSeconds;
 extern NSString *const kVungleUserId;
 extern NSString *const kVungleOrdinal;
 extern NSString *const kVungleStartMuted;
+extern NSString *const kVungleSupportedOrientations;
 extern NSString *const kVungleSDKCollectDevice;
 extern NSString *const kVungleSDKMinSpaceForInit;
 extern NSString *const kVungleSDKMinSpaceForAdRequest;


### PR DESCRIPTION
During IE testing, David has noticed that there is option available for interstitial ads to have extra objects to be passed for ad customization. However, he noticed that mute setting, which is most used by publishers, is missing and ad orientation is also not there. On the other hand ability to pass user ID is present which is only used for rewarded ads.

IOS-2524