### PR TITLE
[Won’t Merge][IOS-2572][IOS-2573]Implement new VungleSDKDelegate callbacks in MoPub adapter 

### DIFF
--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"6.5.2.0";
+    return @"6.7.0.0";
 }
 
 - (NSString *)biddingToken {

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -137,9 +137,9 @@
     }
 }
 
-- (void)vungleAdWasTapped
+- (void)vungleAdTrackClick
 {
-    MPLogInfo(@"Vungle video banner was tapped");
+    MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     [self.delegate trackClick];
 }
 
@@ -156,7 +156,7 @@
 
 - (void)vungleAdWillLeaveApplication
 {
-    MPLogInfo(@"Vungle video banner will leave the application");
+    MPLogAdEvent([MPLogEvent adWillLeaveApplicationForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     [self.delegate bannerCustomEventWillLeaveApplication:self];
 }
 

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -143,10 +143,16 @@
     [self.delegate interstitialCustomEventDidDisappear:self];
 }
 
-- (void)vungleAdWasTapped
+- (void)vungleAdTrackClick
 {
     MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     [self.delegate interstitialCustomEventDidReceiveTapEvent:self];
+}
+
+- (void)vungleAdWillLeaveApplication
+{
+    MPLogAdEvent([MPLogEvent adWillLeaveApplicationForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
+    [self.delegate interstitialCustomEventWillLeaveApplication:self];
 }
 
 - (void)vungleAdDidFailToLoad:(NSError *)error

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -105,15 +105,21 @@
     [self.delegate rewardedVideoDidDisappearForCustomEvent:self];
 }
 
-- (void)vungleAdWasTapped
+- (void)vungleAdTrackClick
 {
     MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     [self.delegate rewardedVideoDidReceiveTapEventForCustomEvent:self];
 }
 
-- (void)vungleAdShouldRewardUser
+- (void)vungleAdRewardUser
 {
-    [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:[[MPRewardedVideoReward alloc] initWithCurrencyAmount:@(kMPRewardedVideoRewardCurrencyAmountUnspecified)]];
+    [self performSelectorOnMainThread:@selector(rewardUser) withObject:nil waitUntilDone:NO];
+}
+
+- (void)vungleAdWillLeaveApplication
+{
+    MPLogAdEvent([MPLogEvent adWillLeaveApplicationForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
+    [self.delegate rewardedVideoWillLeaveApplicationForCustomEvent:self];
 }
 
 - (void)vungleAdDidFailToLoad:(NSError *)error
@@ -130,6 +136,13 @@
 
 - (NSString *)getPlacementID {
     return self.placementId;
+}
+
+- (void)rewardUser
+{
+    MPRewardedVideoReward *reward = [[MPRewardedVideoReward alloc] initWithCurrencyAmount:@(kMPRewardedVideoRewardCurrencyAmountUnspecified)];
+    MPLogAdEvent([MPLogEvent adShouldRewardUserWithReward:reward], [self getPlacementID]);
+    [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:reward];
 }
 
 @end

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -59,17 +59,15 @@ extern const CGSize kVNGLeaderboardBannerSize;
 - (void)vungleAdDidAppear;
 - (void)vungleAdWillDisappear;
 - (void)vungleAdDidDisappear;
-- (void)vungleAdWasTapped;
+- (void)vungleAdTrackClick;
+- (void)vungleAdWillLeaveApplication;
 - (void)vungleAdDidFailToPlay:(NSError *)error;
 - (void)vungleAdDidFailToLoad:(NSError *)error;
 - (NSString *)getPlacementID;
 
 @optional
 
-- (void)vungleAdShouldRewardUser;
-
-// @note This should only be used with banner ads
-- (void)vungleAdWillLeaveApplication;
+- (void)vungleAdRewardUser;
 
 - (void)vungleBannerAdDidLoadInView:(UIView *)view;
 

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -609,7 +609,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
     }
 }
 
-- (void)vungleWillCloseAdWithViewInfo:(VungleViewInfo *)info placementID:(NSString *)placementID {
+- (void)vungleWillCloseAdForPlacementID:(nonnull NSString *)placementID {
     id<VungleRouterDelegate> targetDelegate;
     
     if ([placementID isEqualToString:self.bannerPlacementID]) {
@@ -623,14 +623,6 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
     }
     
     if (targetDelegate) {
-        if ([info.didDownload isEqual:@YES]) {
-            [targetDelegate vungleAdWasTapped];
-        }
-        
-        if ([info.completedView boolValue] && [targetDelegate respondsToSelector:@selector(vungleAdShouldRewardUser)]) {
-            [targetDelegate vungleAdShouldRewardUser];
-        }
-        
         if ([targetDelegate respondsToSelector:@selector(vungleAdWillDisappear)]) {
             [targetDelegate vungleAdWillDisappear];
         }
@@ -638,7 +630,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
     }
 }
 
-- (void)vungleDidCloseAdWithViewInfo:(VungleViewInfo *)info placementID:(NSString *)placementID {
+- (void)vungleDidCloseAdForPlacementID:(nonnull NSString *)placementID {
     id<VungleRouterDelegate> targetDelegate;
     
     if ([placementID isEqualToString:self.bannerPlacementID]) {
@@ -665,6 +657,51 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
     
     if (targetDelegate && [targetDelegate respondsToSelector:@selector(vungleAdDidDisappear)]) {
         [targetDelegate vungleAdDidDisappear];
+    }
+}
+
+- (void)vungleTrackClickForPlacementID:(nullable NSString *)placementID {
+    if (!placementID) {
+        return;
+    }
+
+    id<VungleRouterDelegate> targetDelegate = nil;
+    if ([placementID isEqualToString:self.bannerPlacementID]) {
+        for (int i = 0; i < self.bannerDelegates.count; i++) {
+            if ((BannerRouterDelegateState)[[self.bannerDelegates[i] valueForKey:kVungleBannerDelegateStateKey] intValue] == BannerRouterDelegateStatePlaying) {
+                targetDelegate = [self.bannerDelegates[i] objectForKey:kVungleBannerDelegateKey];
+            }
+        }
+    } else {
+        targetDelegate = [self.delegatesDict objectForKey:placementID];
+    }
+
+    if (targetDelegate) {
+        [targetDelegate vungleAdTrackClick];
+    }
+}
+
+- (void)vungleRewardUserForPlacementID:(nullable NSString *)placementID {
+    id<VungleRouterDelegate> targetDelegate = [self.delegatesDict objectForKey:placementID];
+    if (targetDelegate && [targetDelegate respondsToSelector:@selector(vungleAdRewardUser)]) {
+        [targetDelegate vungleAdRewardUser];
+    }
+}
+
+- (void)vungleWillLeaveApplicationForPlacementID:(nullable NSString *)placementID {
+    id<VungleRouterDelegate> targetDelegate;
+
+    if ([placementID isEqualToString:self.bannerPlacementID]) {
+        for (int i = 0; i < self.bannerDelegates.count; i++) {
+            if ((BannerRouterDelegateState)[[self.bannerDelegates[i] valueForKey:kVungleBannerDelegateStateKey] intValue] == BannerRouterDelegateStatePlaying) {
+                targetDelegate = [self.bannerDelegates[i] objectForKey:kVungleBannerDelegateKey];
+            }
+        }
+    } else {
+        targetDelegate = [self.delegatesDict objectForKey:placementID];
+    }
+    if (targetDelegate) {
+        [targetDelegate vungleAdWillLeaveApplication];
     }
 }
 


### PR DESCRIPTION
1. Implement below delegate callbacks in MoPub adapter
- (void)vungleTrackClickForPlacementID:(nullable NSString *)placementID;
- (void)vungleRewardUserForPlacementID:(nullable NSString *)placementID;
- (void)vungleWillLeaveApplicationForPlacementID:(nullable NSString *)placementID;
2、Verify all callbacks are set properly
IOS-2572
IOS-2573
