### PR TITLE
[IOS-2767]Support flexible banner sizes in Mopub adapters

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+* 6.5.2.0
+   * This version of the adapters has been certified with Vungle 6.5.2.
+   * Add support for Flexible Banner.
+
   * 6.5.1.1
     * This version of the adapters has been certified with Vungle 6.5.1.
     * Add support for the newly-introduced Vungle's Banner format demand.

--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 #pragma mark - MPAdapterConfiguration
 
 - (NSString *)adapterVersion {
-    return @"6.5.1.1";
+    return @"6.5.2.0";
 }
 
 - (NSString *)biddingToken {

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -50,7 +50,7 @@
         return;
     }
 
-    self.bannerSize = isMediumRectangleFormat ? kVNGMRECSize : size;
+    self.bannerSize = isMediumRectangleFormat ? kVNGMRECSize : [self sizeForCustomEventInfo:size];
     self.bannerInfo = info;
     self.isAdCached = NO;
     
@@ -66,6 +66,22 @@
 - (void) invalidate
 {
     [[VungleRouter sharedRouter] invalidateBannerAdViewForPlacementID:self.placementId delegate:self];
+}
+
+- (CGSize)sizeForCustomEventInfo:(CGSize)size
+{
+    CGFloat width = size.width;
+    CGFloat height = size.height;
+
+    if (height >= kVNGLeaderboardBannerSize.height && width >= kVNGLeaderboardBannerSize.width) {
+        return kVNGLeaderboardBannerSize;
+    } else if (height >= kVNGBannerSize.height && width >= kVNGBannerSize.width) {
+        return kVNGBannerSize;
+    } else if (height >= kVNGShortBannerSize.height && width >= kVNGShortBannerSize.width) {
+        return kVNGShortBannerSize;
+    } else {
+        return kVNGShortBannerSize;
+    }
 }
 
 #pragma mark - VungleRouterDelegate Methods

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -225,7 +225,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
         }
     }
     
-    if ([self validateInfoData:info] && (CGSizeEqualToSize(size, kVNGMRECSize) || CGSizeEqualToSize(size, kVNGBannerSize) || CGSizeEqualToSize(size, kVNGLeaderboardBannerSize))) {
+    if ([self validateInfoData:info] && (CGSizeEqualToSize(size, kVNGMRECSize) || CGSizeEqualToSize(size, kVNGBannerSize) || CGSizeEqualToSize(size, kVNGLeaderboardBannerSize) || CGSizeEqualToSize(size, kVNGShortBannerSize))) {
         self.bannerPlacementID = [info objectForKey:kVunglePlacementIdKey];
         self.isInvalidatedBannerForPlacementID = NO;
         

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -306,10 +306,10 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options forPlacementId:(NSString *)placementId {
     if (!self.isAdPlaying && [self isAdAvailableForPlacementId:placementId]) {
         self.isAdPlaying = YES;
-        NSError *error;
+        NSError *error = nil;
         BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId error:&error];
         if (!success) {
-            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:nil];
+            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:error ?: [NSError errorWithCode:MOPUBErrorVideoPlayerFailedToPlay localizedDescription:@"Failed to play Vungle Interstitial Ad."]];
             self.isAdPlaying = NO;
         }
     } else {
@@ -345,10 +345,11 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
         
         options[VunglePlayAdOptionKeyOrientations] = orientations;
         
-        BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId error:nil];
+        NSError *error = nil;
+        BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId error:&error];
         
         if (!success) {
-            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:nil];
+            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:error ?: [NSError errorWithCode:MOPUBErrorVideoPlayerFailedToPlay localizedDescription:@"Failed to play Vungle Rewarded Video Ad."]];
             self.isAdPlaying = NO;
         }
     } else {


### PR DESCRIPTION
Currently our Mopub adapter has a strict check that the ad size should conform to our supported banner sizes (300x250, 320x50, 728x90). We should modify the restriction so that if the ad size (passed in by publisher via Mopub adapter) does not match Vungle's supported banner sizes, we should get the closed supported ad size; like Admob and FAN does (preferably like what Admob does). Mopub made this request when we submitted our PR.This change will be part of 6.5.2 adapter (on top of 6.5.2 SDK).

Admob:
https://github.com/mopub/mopub-ios-mediation/blob/master/AdMob/MPGoogleAdMobBannerCustomEvent.m#L97
FAN:
https://github.com/mopub/mopub-ios-mediation/blob/master/FacebookAudienceNetwork/FacebookBannerCustomEvent.m#L54

IOS-2767