### PR TITLE
[IOS-2788]Pass out error when failed to play Rewarded Video and Interstitial Ad

### DIFF
--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -306,10 +306,10 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options forPlacementId:(NSString *)placementId {
     if (!self.isAdPlaying && [self isAdAvailableForPlacementId:placementId]) {
         self.isAdPlaying = YES;
-        NSError *error;
+        NSError *error = nil;
         BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId error:&error];
         if (!success) {
-            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:nil];
+            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:error ?: [NSError errorWithCode:MOPUBErrorVideoPlayerFailedToPlay localizedDescription:@"Failed to play Vungle Interstitial Ad."]];
             self.isAdPlaying = NO;
         }
     } else {
@@ -345,10 +345,11 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
         
         options[VunglePlayAdOptionKeyOrientations] = orientations;
         
-        BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId error:nil];
+        NSError *error = nil;
+        BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId error:&error];
         
         if (!success) {
-            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:nil];
+            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:error ?: [NSError errorWithCode:MOPUBErrorVideoPlayerFailedToPlay localizedDescription:@"Failed to play Vungle Rewarded Video Ad."]];
             self.isAdPlaying = NO;
         }
     } else {


### PR DESCRIPTION
In the process of investigating the issue IOS-2769: MoPub interstitial and rewarded ad fails to play using MoPub iOS SDK 5.10.0 and 5.11.0IN PROGRESS(https://vungle.atlassian.net/browse/IOS-2769),  find  an issue about MoPub Adapter, in the method `presentRewardedVideoAdFromViewController:customerId:` of `VungleRouter` class:

`
BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId error:nil];`
       ` if (!success) {
            [[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:nil];
            self.isAdPlaying = NO;
        }
`


In the above implementation, `[[self.delegatesDict objectForKey:placementId] vungleAdDidFailToPlay:nil];` will have a change to cause a crash like this `Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value sometimes.`

The method `presentInterstitialAdFromViewController:options:forPlacementId:` of `VungleRouter` also needs the same modification.

IOS-2788