### PR TITLE
Not serve Banner ad for iOS 9

### DIFF
--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -33,6 +33,11 @@
 
 - (void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup
 {
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] == NSOrderedAscending) {
+        MPLogError(@"Vungle only serves Banner ad on system version greater than or equal to 10.0.");
+        return;
+    }
+
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.options = nil;
     


### PR DESCRIPTION
Add a protection in the MoPub Adapter, if the device iOS version is less than 10.0, the MoPub Adapter will reject to request Banner ad.