### PR TITLE
[IOS-2923]6.7.x MoPub Adapter Multiple Ad play support

### DIFF
--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -65,8 +65,8 @@
 
 - (void) invalidate
 {
-    [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId
-                                                           delegate:self];
+    [[VungleRouter sharedRouter] invalidateBannerAdViewForPlacementID:self.placementId
+                                                             delegate:self];
 }
 
 - (CGSize)sizeForCustomEventInfo:(CGSize)size
@@ -129,8 +129,7 @@
     bannerAdView = [[VungleRouter sharedRouter] renderBannerAdInView:bannerAdView options:self.options forPlacementID:self.placementId size:self.bannerSize];
     
     if (bannerAdView) {
-        [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId
-                                                               delegate:self];
+        [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId];
         [self.delegate bannerCustomEvent:self didLoadAd:bannerAdView];
         [self.delegate trackImpression];
         self.isAdCached = YES;

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -65,7 +65,8 @@
 
 - (void) invalidate
 {
-    [[VungleRouter sharedRouter] invalidateBannerAdViewForPlacementID:self.placementId delegate:self];
+    [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId
+                                                           delegate:self];
 }
 
 - (CGSize)sizeForCustomEventInfo:(CGSize)size
@@ -128,7 +129,8 @@
     bannerAdView = [[VungleRouter sharedRouter] renderBannerAdInView:bannerAdView options:self.options forPlacementID:self.placementId size:self.bannerSize];
     
     if (bannerAdView) {
-        [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId];
+        [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId
+                                                               delegate:self];
         [self.delegate bannerCustomEvent:self didLoadAd:bannerAdView];
         [self.delegate trackImpression];
         self.isAdCached = YES;

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -44,8 +44,8 @@ extern const CGSize kVNGLeaderboardBannerSize;
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options forPlacementId:(NSString *)placementId;
 - (void)presentRewardedVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId settings:(VungleInstanceMediationSettings *)settings forPlacementId:(NSString *)placementId;
 - (UIView *)renderBannerAdInView:(UIView *)bannerView options:(NSDictionary *)options forPlacementID:(NSString *)placementID size:(CGSize)size;
-- (void)completeBannerAdViewForPlacementID:(NSString *)placementID;
-- (void)invalidateBannerAdViewForPlacementID:(NSString *)placementID delegate:(id<VungleRouterDelegate>)delegate;
+- (void)completeBannerAdViewForPlacementID:(NSString *)placementID
+                                  delegate:(id<VungleRouterDelegate>)delegate;
 - (void)updateConsentStatus:(VungleConsentStatus)status;
 - (VungleConsentStatus) getCurrentConsentStatus;
 - (void)clearDelegateForPlacementId:(NSString *)placementId;

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -44,8 +44,9 @@ extern const CGSize kVNGLeaderboardBannerSize;
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options forPlacementId:(NSString *)placementId;
 - (void)presentRewardedVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId settings:(VungleInstanceMediationSettings *)settings forPlacementId:(NSString *)placementId;
 - (UIView *)renderBannerAdInView:(UIView *)bannerView options:(NSDictionary *)options forPlacementID:(NSString *)placementID size:(CGSize)size;
-- (void)completeBannerAdViewForPlacementID:(NSString *)placementID
-                                  delegate:(id<VungleRouterDelegate>)delegate;
+- (void)completeBannerAdViewForPlacementID:(NSString *)placementID;
+- (void)invalidateBannerAdViewForPlacementID:(NSString *)placementID
+                                    delegate:(id<VungleRouterDelegate>)delegate;
 - (void)updateConsentStatus:(VungleConsentStatus)status;
 - (VungleConsentStatus) getCurrentConsentStatus;
 - (void)clearDelegateForPlacementId:(NSString *)placementId;


### PR DESCRIPTION
This PR includes the implementations of 6.7.x MoPub Adapter Multiple Ad play support, the previous MoPub Adapter versions add some restriction to make sure only one Banner or MREC ad can play at a time, this PR removes these restriction and supports playing Multiple Ad.


IOS-2923