### PR TITLE
[IOS-2993]Set CCPA status at adapter level

### DIFF
--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -69,7 +69,12 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
         self.shouldCollectDeviceId = [configuration[kVungleSDKCollectDevice] boolValue];
         [VungleRouter.sharedRouter setShouldCollectDeviceId:self.shouldCollectDeviceId];
     }
-    
+
+    if (configuration[kVungleSDKCCPAStatus]) {
+        VungleCCPAStatus vungleCCPAStatus = (VungleCCPAStatus)[configuration[kVungleSDKCCPAStatus] integerValue];
+        [VungleRouter.sharedRouter setCCPAStatus:vungleCCPAStatus];
+    }
+
     NSMutableDictionary *sizeOverrideDict = [NSMutableDictionary dictionary];
     if (configuration[kVNGSDKOptionsMinSpaceForInit]) {
         [sizeOverrideDict setValue:configuration[kVNGSDKOptionsMinSpaceForInit] forKey:kVungleSDKMinSpaceForInit];

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -17,6 +17,7 @@ extern NSString * const kVungleOrdinal;
 extern NSString * const kVungleStartMuted;
 extern NSString * const kVungleSupportedOrientations;
 extern NSString * const kVungleSDKCollectDevice;
+extern NSString * const kVungleSDKCCPAStatus;
 extern NSString * const kVungleSDKMinSpaceForInit;
 extern NSString * const kVungleSDKMinSpaceForAdRequest;
 extern NSString * const kVungleSDKMinSpaceForAssetLoad;
@@ -35,6 +36,7 @@ extern const CGSize kVNGLeaderboardBannerSize;
 
 - (void)initializeSdkWithInfo:(NSDictionary *)info;
 - (void)setShouldCollectDeviceId:(BOOL)shouldCollectDeviceId;
+- (void)setCCPAStatus:(VungleCCPAStatus)vungleCCPAStatus;
 - (void)setSDKOptions:(NSDictionary *)sdkOptions;
 - (void)requestInterstitialAdWithCustomEventInfo:(NSDictionary *)info delegate:(id<VungleRouterDelegate>)delegate;
 - (void)requestRewardedVideoAdWithCustomEventInfo:(NSDictionary *)info delegate:(id<VungleRouterDelegate>)delegate;

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -25,6 +25,7 @@ NSString * const kVungleStartMuted = @"muted";
 NSString * const kVungleSupportedOrientations = @"orientations";
 
 NSString * const kVungleSDKCollectDevice = @"collectDevice";
+NSString * const kVungleSDKCCPAStatus = @"vungleCCPAStatus";
 NSString * const kVungleSDKMinSpaceForInit = @"vungleMinimumFileSystemSizeForInit";
 NSString * const kVungleSDKMinSpaceForAdRequest = @"vungleMinimumFileSystemSizeForAdRequest";
 NSString * const kVungleSDKMinSpaceForAssetLoad = @"vungleMinimumFileSystemSizeForAssetDownload";
@@ -157,6 +158,11 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
     if (self.sdkInitializeState == SDKInitializeStateNotInitialized) {
         [VungleSDK setPublishIDFV:shouldCollectDeviceId];
     }
+}
+
+- (void)setCCPAStatus:(VungleCCPAStatus)vungleCCPAStatus
+{
+    [[VungleSDK sharedSDK] updateCCPAStatus:vungleCCPAStatus];
 }
 
 - (void)setSDKOptions:(NSDictionary *)sdkOptions


### PR DESCRIPTION
Regarding CCPA, there are concerns raised by IE team about setting CCPA via SDK instead via adapters. 

For MoPub Adapter, we can use `configDictionary` for `setNetworkConfiguration` to pass CCPA data from pubs. So we need to take care of CCPA in `configDictionary` at adapter level.

IOS-2993