### PR TITLE
[IOS-3093]Fix display issue after clicking Banner

### DIFF
--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -151,6 +151,7 @@
     [self.delegate inlineAdAdapterWillBeginUserAction:self];
     MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], self.getPlacementID);
     [self.delegate inlineAdAdapterDidTrackClick:self];
+    [self.delegate inlineAdAdapterDidEndUserAction:self];
 }
 
 - (void)vungleAdDidFailToLoad:(NSError *)error


### PR DESCRIPTION
During testing our iOS 6.7.0.0 MoPub Adapter which rebased on the latest changes of Vungle 6.5.3.2 Adapter with MoPub 5.13.0 SDK, I found below issue:
When we click a Banner, then the App will jump to Safari. When we go back to App, the Banner view cannot display the Banner.
Through debugging, I found this issue was introduced in Vungle Adapter - 6.5.3.2(https://github.com/mopub/mopub-ios-mediation/commit/1b8e91fbbdeab4c74292bbf20d52fb87157b3eb0).

This PR is the fix for this Banner display issue after clicking it.

IOS-3093