### PR TITLE
[IOS-3131]Fix HBP initialized issue

### DIFF
--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -133,7 +133,12 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
             NSError * error = nil;
             // Disable refresh functionality for all banners
             [[VungleSDK sharedSDK] disableBannerRefresh];
-            [[VungleSDK sharedSDK] startWithAppId:appId options:initOptions error:&error];
+            BOOL started = [[VungleSDK sharedSDK] startWithAppId:appId options:initOptions error:&error];
+            if (!started && error.code == VungleSDKErrorSDKAlreadyInitializing) {
+                MPLogInfo(@"Vungle:SDK already has been initialized.");
+                self.sdkInitializeState = SDKInitializeStateInitialized;
+                [self clearWaitingList];
+            }
             [[VungleSDK sharedSDK] setDelegate:self];
             [[VungleSDK sharedSDK] setNativeAdsDelegate:self];
         });


### PR DESCRIPTION
When doing HBP test,  I found an issue when MoPub Adapter tried to initialize our native SDK which already had been initialized.  This issue was caused by the change for ticket IOS-3069(https://vungle.atlassian.net/browse/IOS-3069): "[Mopub with early initialization] /config API was called twice whenever SDK was initialized" in our native 6.7.1 SDK. 
This PR fixed this issue.

IOS-3131