### PR TITLE
[IOS-3246]Remove VungleSDKResetPlacementForDifferentAdSize error check when load Ads

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 * 6.8.0.0
     * This version of the adapters has been certified with Vungle 6.8.0 and MoPub SDK 5.13.1.
+    * Remove VungleSDKResetPlacementForDifferentAdSize error check for loading Ads.
 
 * 6.7.1.0
     * This version of the adapters has been certified with Vungle 6.7.1 and MoPub SDK 5.13.1.

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -313,11 +313,15 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                     if ([[VungleSDK sharedSDK] loadPlacementWithID:placementID withSize:[self getVungleBannerAdSizeType:size] error:&error]) {
                         MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", placementID);
                     } else {
-                        if ((error) && (error.code != VungleSDKResetPlacementForDifferentAdSize)) {
-                            [self requestBannerAdFailedWithError:error
-                                                     placementID:placementID
-                                                        delegate:delegate];
+                        if (!error) {
+                            NSString *errorMessage = [NSString stringWithFormat:@"Vungle: Unable to load an ad for Placement ID: %@.", placementID];
+                            error = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd
+                                      localizedDescription:errorMessage];
                         }
+                        [self requestBannerAdFailedWithError:error
+                                                 placementID:placementID
+                                                    delegate:delegate];
+                        MPLogError(@"%@", error);
                     }
                 }
             }


### PR DESCRIPTION
Currently when Banner ad is requested with different ad size from the size of `cached ad`, `loadPlacementWithID` in `VunglePlacementsCoordinator` will return `Yes` and not return `NO` or `error` any more in our native SDK. So we could remove the `VungleSDKResetPlacementForDifferentAdSize` error code check when requesting a different Banner ad size from  the size of `cached Banner ad`.

IOS-3246