### PR TITLE
[IOS-3313]Fix the issues reported by publisher

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -2,6 +2,7 @@
 * 6.9.0.0
     * This version of the adapters has been certified with Vungle 6.9.0 and MoPub SDK 5.14.1.
     * Remove VungleSDKResetPlacementForDifferentAdSize error check for loading Ads.
+    * Fix the issue that fullscreen ads fail to load.
 
 * 6.8.1.0
     * This version of the adapters has been certified with Vungle 6.8.1 and MoPub SDK 5.14.1.

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -544,7 +544,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
                 if ([self isAdAvailableForPlacementId:key]) {
                     [delegateInstance vungleAdDidLoad];
-                    return;
+                    continue;
                 }
 
                 NSError *error = nil;

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -46,11 +46,10 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 @property (nonatomic) BOOL isAdPlaying;
 @property (nonatomic) SDKInitializeState sdkInitializeState;
 
-@property (nonatomic) NSMutableDictionary *delegatesDict;
 @property (nonatomic) NSMutableDictionary *waitingListDict;
+@property (nonatomic) NSMapTable<NSString *, id<VungleRouterDelegate>> *delegatesDict;
 @property (nonatomic) NSMapTable<NSString *, id<VungleRouterDelegate>> *bannerDelegates;
 
-@property (nonatomic, copy) NSString *prioritizedPlacementID;
 @end
 
 @implementation VungleRouter
@@ -59,7 +58,8 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 {
     if (self = [super init]) {
         self.sdkInitializeState = SDKInitializeStateNotInitialized;
-        self.delegatesDict = [NSMutableDictionary dictionary];
+        self.delegatesDict = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsStrongMemory
+                                                   valueOptions:NSPointerFunctionsWeakMemory];
         self.waitingListDict = [NSMutableDictionary dictionary];
         self.bannerDelegates = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsStrongMemory
                                                      valueOptions:NSPointerFunctionsWeakMemory];
@@ -118,7 +118,6 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         
         if (placementID.length && delegateInstance) {
             [initOptions setObject:placementID forKey:VungleSDKInitOptionKeyPriorityPlacementID];
-            self.prioritizedPlacementID = [placementID copy];
 
             NSInteger priorityPlacementAdSize = 1;
             if ([delegateInstance respondsToSelector:@selector(getBannerSize)]) {
@@ -253,7 +252,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
             }
         } else if (self.sdkInitializeState == SDKInitializeStateInitialized) {
             NSString *placementID = [info objectForKey:kVunglePlacementIdKey];
-            [self requestBannerAdWithPlacementID:placementID size:size delegate:delegate needRequestAd:YES];
+            [self requestBannerAdWithPlacementID:placementID size:size delegate:delegate];
         }
     } else {
         MPLogError(@"Vungle: A banner ad type was requested with the size which Vungle SDK doesn't support.");
@@ -269,6 +268,11 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         [self.delegatesDict setObject:delegate forKey:placementId];
     }
     
+    if ([self isAdAvailableForPlacementId:placementId]) {
+        [delegate vungleAdDidLoad];
+        return;
+    }
+
     NSError *error = nil;
     if ([[VungleSDK sharedSDK] loadPlacementWithID:placementId error:&error]) {
         MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", placementId);
@@ -283,7 +287,6 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 - (void)requestBannerAdWithPlacementID:(NSString *)placementID
                                   size:(CGSize)size
                               delegate:(id<VungleRouterDelegate>)delegate
-                         needRequestAd:(BOOL)needRequestAd
 {
     @synchronized (self) {
         if ([self isBannerAdAvailableForPlacementId:placementID size:size]) {
@@ -299,30 +302,28 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                 [self.bannerDelegates setObject:delegate forKey:placementID];
             }
 
-            if (needRequestAd) {
-                NSError *error = nil;
-                if (CGSizeEqualToSize(size, kVNGMRECSize)) {
-                    if ([[VungleSDK sharedSDK] loadPlacementWithID:placementID error:&error]) {
-                        MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", placementID);
-                    } else {
-                        [self requestBannerAdFailedWithError:error
-                                                 placementID:placementID
-                                                    delegate:delegate];
-                    }
+            NSError *error = nil;
+            if (CGSizeEqualToSize(size, kVNGMRECSize)) {
+                if ([[VungleSDK sharedSDK] loadPlacementWithID:placementID error:&error]) {
+                    MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", placementID);
                 } else {
-                    if ([[VungleSDK sharedSDK] loadPlacementWithID:placementID withSize:[self getVungleBannerAdSizeType:size] error:&error]) {
-                        MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", placementID);
-                    } else {
-                        if (!error) {
-                            NSString *errorMessage = [NSString stringWithFormat:@"Vungle: Unable to load an ad for Placement ID: %@.", placementID];
-                            error = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd
-                                      localizedDescription:errorMessage];
-                        }
-                        [self requestBannerAdFailedWithError:error
-                                                 placementID:placementID
-                                                    delegate:delegate];
-                        MPLogError(@"%@", error);
+                    [self requestBannerAdFailedWithError:error
+                                             placementID:placementID
+                                                delegate:delegate];
+                }
+            } else {
+                if ([[VungleSDK sharedSDK] loadPlacementWithID:placementID withSize:[self getVungleBannerAdSizeType:size] error:&error]) {
+                    MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", placementID);
+                } else {
+                    if (!error) {
+                        NSString *errorMessage = [NSString stringWithFormat:@"Vungle: Unable to load an ad for Placement ID: %@.", placementID];
+                        error = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd
+                                  localizedDescription:errorMessage];
                     }
+                    [self requestBannerAdFailedWithError:error
+                                             placementID:placementID
+                                                delegate:delegate];
+                    MPLogError(@"%@", error);
                 }
             }
         }
@@ -528,44 +529,38 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)clearWaitingList
 {
-    for (id key in self.waitingListDict) {
-        id<VungleRouterDelegate> delegateInstance = [self.waitingListDict objectForKey:key];
-        
-        NSString *targetPlacementID = [delegateInstance getPlacementID];
-        BOOL needRequestAd = YES;
-        
-        // If a placement is requested as priority placement at init call, no need to request again.
-        if ([self.prioritizedPlacementID isEqualToString:targetPlacementID]) {
-            needRequestAd = NO;
-        }
-        
-        if ([delegateInstance respondsToSelector:@selector(getBannerSize)]) {
-            NSString *id = [delegateInstance getPlacementID];
-            CGSize size = [delegateInstance getBannerSize];
-            [self requestBannerAdWithPlacementID:id size:size delegate:delegateInstance needRequestAd:needRequestAd];
-        } else {
-            if (![self.delegatesDict objectForKey:key]) {
-                [self.delegatesDict setObject:delegateInstance forKey:key];
-            }
-            
-            if (!needRequestAd) {
-                continue;
-            }
-            
-            NSError *error = nil;
-            if ([[VungleSDK sharedSDK] loadPlacementWithID:key error:&error]) {
-                MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", key);
+    @synchronized (self) {
+        for (id key in self.waitingListDict) {
+            id<VungleRouterDelegate> delegateInstance = [self.waitingListDict objectForKey:key];
+
+            if ([delegateInstance respondsToSelector:@selector(getBannerSize)]) {
+                NSString *id = [delegateInstance getPlacementID];
+                CGSize size = [delegateInstance getBannerSize];
+                [self requestBannerAdWithPlacementID:id size:size delegate:delegateInstance];
             } else {
-                if (error) {
-                    MPLogInfo(@"Vungle: Unable to load an ad for Placement ID :%@, Error %@", key, error);
+                if (![self.delegatesDict objectForKey:key]) {
+                    [self.delegatesDict setObject:delegateInstance forKey:key];
                 }
-                [delegateInstance vungleAdDidFailToLoad:error];
+
+                if ([self isAdAvailableForPlacementId:key]) {
+                    [delegateInstance vungleAdDidLoad];
+                    return;
+                }
+
+                NSError *error = nil;
+                if ([[VungleSDK sharedSDK] loadPlacementWithID:key error:&error]) {
+                    MPLogInfo(@"Vungle: Start to load an ad for Placement ID :%@", key);
+                } else {
+                    if (error) {
+                        MPLogInfo(@"Vungle: Unable to load an ad for Placement ID :%@, Error %@", key, error);
+                    }
+                    [delegateInstance vungleAdDidFailToLoad:error];
+                }
             }
         }
+
+        [self.waitingListDict removeAllObjects];
     }
-    
-    [self.waitingListDict removeAllObjects];
-    self.prioritizedPlacementID = nil;
 }
 
 - (void)requestBannerAdFailedWithError:(NSError *)error
@@ -657,21 +652,26 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         return;
     }
 
+    NSString *message = error ? [NSString stringWithFormat:@"Vungle: Ad playability update returned error for Placement ID: %@, Error: %@", placementID, error.localizedDescription] : [NSString stringWithFormat:@"Vungle: Ad playability update returned Ad is not playable for Placement ID: %@.", placementID];
+    NSError *playabilityError = error ? : [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:message];
+
+    @synchronized (self) {
+        if (self.sdkInitializeState == SDKInitializeStateNotInitialized && !isAdPlayable) {
+            if ([self.waitingListDict objectForKey:placementID]) {
+                id<VungleRouterDelegate> delegate = [self.waitingListDict objectForKey:placementID];
+                [delegate vungleAdDidFailToLoad:playabilityError];
+                [self.waitingListDict removeObjectForKey:placementID];
+                return;
+            }
+        }
+    }
+
     if ([self.delegatesDict objectForKey:placementID]) {
         if (isAdPlayable) {
             MPLogInfo(@"Vungle: Ad playability update returned ad is playable for Placement ID: %@", placementID);
             [[self.delegatesDict objectForKey:placementID] vungleAdDidLoad];
         } else {
-            NSError *playabilityError = nil;
-            if (error) {
-                MPLogInfo(@"Vungle: Ad playability update returned error for Placement ID: %@, Error: %@", placementID, error.localizedDescription);
-                playabilityError = error;
-            } else {
-                NSString *message = [NSString stringWithFormat:@"Vungle: Ad playability update returned Ad is not playable for Placement ID: %@.", placementID];
-                MPLogInfo(@"%@", message);
-                playabilityError = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:message];
-            }
-
+            MPLogInfo(@"%@", message);
             if (!self.isAdPlaying) {
                 [[self.delegatesDict objectForKey:placementID] vungleAdDidFailToLoad:playabilityError];
             }
@@ -688,15 +688,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                     [bannerDelegate vungleAdDidLoad];
                     bannerDelegate.bannerState = BannerRouterDelegateStateCached;
                 } else {
-                    NSError *playabilityError = nil;
-                    if (error) {
-                        MPLogInfo(@"Vungle: Ad playability update returned error for Placement ID: %@, Error: %@", placementID, error.localizedDescription);
-                        playabilityError = error;
-                    } else {
-                        NSString *message = [NSString stringWithFormat:@"Vungle: Ad playability update returned Ad is not playable for Placement ID: %@.", placementID];
-                        MPLogInfo(@"%@", message);
-                        playabilityError = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:message];
-                    }
+                    MPLogInfo(@"%@", message);
                     [bannerDelegate vungleAdDidFailToLoad:playabilityError];
                     bannerDelegate.bannerState = BannerRouterDelegateStateClosed;
                     needToClearDelegate = YES;

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -652,8 +652,12 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         return;
     }
 
-    NSString *message = error ? [NSString stringWithFormat:@"Vungle: Ad playability update returned error for Placement ID: %@, Error: %@", placementID, error.localizedDescription] : [NSString stringWithFormat:@"Vungle: Ad playability update returned Ad is not playable for Placement ID: %@.", placementID];
-    NSError *playabilityError = error ? : [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:message];
+    NSString *message = nil;
+    NSError *playabilityError = nil;
+    if (!isAdPlayable) {
+        message = error ? [NSString stringWithFormat:@"Vungle: Ad playability update returned error for Placement ID: %@, Error: %@", placementID, error.localizedDescription] : [NSString stringWithFormat:@"Vungle: Ad playability update returned Ad is not playable for Placement ID: %@.", placementID];
+        playabilityError = error ? : [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:message];
+    }
 
     @synchronized (self) {
         if (self.sdkInitializeState == SDKInitializeStateNotInitialized && !isAdPlayable) {


### PR DESCRIPTION
This PR is fixing the issues reported by publisher in ticket [IOS-3313](https://vungle.atlassian.net/browse/IOS-3313), which includes 4 updates:
1、Use weak reference for fullscreen ads, so if timeout happened, the stale delegate will be recycled by iOS system.
2、Before loading an ad, we will check if the ad is cached.
3、For `playability update` callback BEFORE `SDK initialized` callback issue,  we will check the SDK initialization status in `playability update` method and do related operation.
4、Remove the change in PR [https://github.com/Vungle/mopub-ios-mediation/pull/19/files.](https://github.com/Vungle/mopub-ios-mediation/pull/19/files.)

IOS-3313