### PR TITLE
[IOS-3428]Implement new SDK callback `vungleAdViewedForPlacement:` in MoPub adapter

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -3,6 +3,7 @@
     * This version of the adapters has been certified with Vungle 6.9.0 and MoPub SDK 5.14.1.
     * Remove VungleSDKResetPlacementForDifferentAdSize error check for loading Ads.
     * Fix the issue that fullscreen ads fail to load.
+    * Introduce the new SDK delegate callback `vungleAdViewedForPlacement:` to track views.
 
 * 6.8.1.0
     * This version of the adapters has been certified with Vungle 6.8.1 and MoPub SDK 5.14.1.

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -152,7 +152,6 @@
         MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], self.getPlacementID);
         MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], self.getPlacementID);
         [self.delegate inlineAdAdapter:self didLoadAdWithAdView:bannerAdView];
-        [self.delegate inlineAdAdapterDidTrackImpression:self];
         MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], self.getPlacementID);
         self.isAdCached = YES;
     } else {
@@ -214,6 +213,12 @@
 - (void)vungleAdDidAppear
 {
     MPLogInfo(@"Vungle video banner did appear");
+}
+
+- (void)vungleAdViewed
+{
+    MPLogInfo(@"Vungle video banner did viewed");
+    [self.delegate inlineAdAdapterDidTrackImpression:self];
 }
 
 - (void)vungleAdDidDisappear {

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -217,7 +217,7 @@
 
 - (void)vungleAdViewed
 {
-    MPLogInfo(@"Vungle video banner did viewed");
+    MPLogInfo(@"Vungle video banner did view");
     [self.delegate inlineAdAdapterDidTrackImpression:self];
 }
 

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -146,6 +146,11 @@
     MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     [self.delegate fullscreenAdAdapterAdDidAppear:self];
+}
+
+- (void)vungleAdViewed
+{
+    MPLogInfo(@"Vungle Interstitial Ad did viewed");
     [self.delegate fullscreenAdAdapterDidTrackImpression:self];
 }
 

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -150,7 +150,7 @@
 
 - (void)vungleAdViewed
 {
-    MPLogInfo(@"Vungle Interstitial Ad did viewed");
+    MPLogInfo(@"Vungle Interstitial Ad did view");
     [self.delegate fullscreenAdAdapterDidTrackImpression:self];
 }
 

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -109,6 +109,11 @@
     MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], [self getPlacementID]);
     [self.delegate fullscreenAdAdapterAdDidAppear:self];
+}
+
+- (void)vungleAdViewed
+{
+    MPLogInfo(@"Vungle Rewarded Video Ad did viewed");
     [self.delegate fullscreenAdAdapterDidTrackImpression:self];
 }
 

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -113,7 +113,7 @@
 
 - (void)vungleAdViewed
 {
-    MPLogInfo(@"Vungle Rewarded Video Ad did viewed");
+    MPLogInfo(@"Vungle Rewarded Video Ad did view");
     [self.delegate fullscreenAdAdapterDidTrackImpression:self];
 }
 

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -69,6 +69,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)vungleAdDidLoad;
 - (void)vungleAdWillAppear;
 - (void)vungleAdDidAppear;
+- (void)vungleAdViewed;
 - (void)vungleAdWillDisappear;
 - (void)vungleAdDidDisappear;
 - (void)vungleAdTrackClick;

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -724,6 +724,10 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     }
 }
 
+- (void)vungleAdViewedForPlacement:(NSString *)placementID {
+    MPLogInfo(@"Vungle: Receive 'vungleAdViewedForPlacement' event for Placement ID: %@.", placementID);
+}
+
 - (void)vungleWillCloseAdForPlacementID:(nonnull NSString *)placementID
 {
     id<VungleRouterDelegate> targetDelegate = [self.delegatesDict objectForKey:placementID];

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -724,8 +724,21 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     }
 }
 
-- (void)vungleAdViewedForPlacement:(NSString *)placementID {
-    MPLogInfo(@"Vungle: Receive 'vungleAdViewedForPlacement' event for Placement ID: %@.", placementID);
+- (void)vungleAdViewedForPlacement:(NSString *)placementID
+{
+    if (!placementID.length) {
+        return;
+    }
+
+    id<VungleRouterDelegate> targetDelegate = [self.delegatesDict objectForKey:placementID];
+    if (!targetDelegate) {
+        @synchronized (self) {
+            targetDelegate =
+            [self getBannerDelegateWithPlacement:placementID
+                                 withBannerState:BannerRouterDelegateStatePlaying];
+        }
+    }
+    [targetDelegate vungleAdViewed];
 }
 
 - (void)vungleWillCloseAdForPlacementID:(nonnull NSString *)placementID


### PR DESCRIPTION
This PR is implementing the new SDK callback `vungleAdViewedForPlacement:` in MoPub adapter. As synced with MoPub side, the mapping relation is below:
 Vungle: - (void)vungleAdViewedForPlacement:--> MoPub: DidTrackImpression

IOS-3428