### PR TITLE
[IOS-3435]Use correct key and remove invalid play option keys

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -4,6 +4,7 @@
     * Remove VungleSDKResetPlacementForDifferentAdSize error check for loading Ads.
     * Fix the issue that fullscreen ads fail to load.
     * Introduce the new SDK delegate callback `vungleAdViewedForPlacement:` to track views.
+    * Remove invalid play option keys.
 
 * 6.8.1.0
     * This version of the adapters has been certified with Vungle 6.8.1 and MoPub SDK 5.14.1.

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -112,14 +112,6 @@
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
     
     if (self.localExtras != nil && [self.localExtras count] > 0) {
-        NSString *userId = [self.localExtras objectForKey:kVungleUserId];
-        if (userId != nil) {
-            NSString *userID = userId;
-            if (userID.length > 0) {
-                options[VunglePlayAdOptionKeyUser] = userID;
-            }
-        }
-        
         NSString *ordinal = [self.localExtras objectForKey:kVungleOrdinal];
         if (ordinal != nil) {
             NSNumber *ordinalPlaceholder = [NSNumber numberWithLongLong:[ordinal longLongValue]];

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -120,7 +120,7 @@
             }
         }
         
-        NSString *ordinal = [self.localExtras objectForKey:kVungleUserId];
+        NSString *ordinal = [self.localExtras objectForKey:kVungleOrdinal];
         if (ordinal != nil) {
             NSNumber *ordinalPlaceholder = [NSNumber numberWithLongLong:[ordinal longLongValue]];
             NSUInteger ordinal = ordinalPlaceholder.unsignedIntegerValue;

--- a/Vungle/VungleInstanceMediationSettings.h
+++ b/Vungle/VungleInstanceMediationSettings.h
@@ -30,8 +30,6 @@
 
 @property (nonatomic) NSUInteger ordinal;
 
-@property (nonatomic) NSTimeInterval flexViewAutoDismissSeconds;
-
 @property (nonatomic) BOOL startMuted;
 
 @property (nonatomic, assign) NSNumber *orientations;

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -76,14 +76,6 @@
                 }
             }
             
-            NSString *flexViewAutoDismissSeconds = [self.localExtras objectForKey:kVungleFlexViewAutoDismissSeconds];
-            if (flexViewAutoDismissSeconds != nil) {
-                NSTimeInterval flexDismissTime = [flexViewAutoDismissSeconds floatValue];
-                if (flexDismissTime > 0) {
-                    options[VunglePlayAdOptionKeyFlexViewAutoDismissSeconds] = @(flexDismissTime);
-                }
-            }
-            
             NSString *muted = [self.localExtras objectForKey:kVungleStartMuted];
             if ( muted != nil) {
                 BOOL startMutedPlaceholder = [muted boolValue];

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -11,7 +11,6 @@
 
 extern NSString *const kVungleAppIdKey;
 extern NSString *const kVunglePlacementIdKey;
-extern NSString *const kVungleFlexViewAutoDismissSeconds;
 extern NSString *const kVungleUserId;
 extern NSString *const kVungleOrdinal;
 extern NSString *const kVungleStartMuted;

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -18,7 +18,6 @@
 
 NSString *const kVungleAppIdKey = @"appId";
 NSString *const kVunglePlacementIdKey = @"pid";
-NSString *const kVungleFlexViewAutoDismissSeconds = @"flexViewAutoDismissSeconds";
 NSString *const kVungleUserId = @"userId";
 NSString *const kVungleOrdinal = @"ordinal";
 NSString *const kVungleStartMuted = @"muted";
@@ -376,10 +375,9 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         } else if (settings && settings.userIdentifier.length > 0) {
             options[VunglePlayAdOptionKeyUser] = settings.userIdentifier;
         }
-        if (settings.ordinal > 0)
+        if (settings.ordinal > 0) {
             options[VunglePlayAdOptionKeyOrdinal] = @(settings.ordinal);
-        if (settings.flexViewAutoDismissSeconds > 0)
-            options[VunglePlayAdOptionKeyFlexViewAutoDismissSeconds] = @(settings.flexViewAutoDismissSeconds);
+        }
         if (settings.startMuted) {
             options[VunglePlayAdOptionKeyStartMuted] = @(settings.startMuted);
         }


### PR DESCRIPTION
This PR is using the correct key for ordinal in localExtras to pass correct play options. 
And this PR also removes the `userId` for Banner Ad play options which is normally used for `Rewarded` purpose and `flexViewAutoDismissSeconds`, because `FlexView` template type ads are no longer supported by our SDK.

IOS-3435