### PR TITLE
[IOS-3482]Fix MoPub Adapter MREC crash

### DIFF
--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -210,7 +210,10 @@
 - (void)vungleAdViewed
 {
     MPLogInfo(@"Vungle video banner did view");
-    [self.delegate inlineAdAdapterDidTrackImpression:self];
+    __weak VungleBannerCustomEvent *weakself = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [weakself.delegate inlineAdAdapterDidTrackImpression:weakself];
+    });
 }
 
 - (void)vungleAdDidDisappear {


### PR DESCRIPTION
This PR is fixing the MoPub Adapter MREC crash found in MoPub Canary Sample App. To avoid this crash, we need to run `inlineAdAdapterDidTrackImpression` on main thread.

IOS-3482