### PR TITLE
[IOS-3547]Optimize the availability of bid token

### DIFF
--- a/Vungle/VungleAdapterConfiguration.m
+++ b/Vungle/VungleAdapterConfiguration.m
@@ -19,6 +19,8 @@ static NSString * const kAdapterErrorDomain = @"com.mopub.mopub-ios-sdk.mopub-vu
 NSString * const kVNGSDKOptionsMinSpaceForInit = @"vngMinSpaceForInit";
 NSString * const kVNGSDKOptionsMinSpaceForAdLoad = @"vngMinSpaceForAdLoad";
 
+static NSString *bidToken = nil;
+
 typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
     VungleAdapterErrorCodeMissingAppId,
 };
@@ -45,7 +47,11 @@ typedef NS_ENUM(NSInteger, VungleAdapterErrorCode) {
 }
 
 - (NSString *)biddingToken {
-    NSString *bidToken = [[VungleRouter sharedRouter] currentSuperToken];
+    NSString *token = [[VungleRouter sharedRouter] currentSuperToken];
+    if (token.length) {
+        bidToken = token;
+    }
+    MPLogInfo(@"Vungle: Get bid token: %@.", bidToken);
     return bidToken;
 }
 

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -339,10 +339,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 }
 
 - (NSString *)currentSuperToken {
-    if (self.sdkInitializeState == SDKInitializeStateInitialized) {
-        return [[VungleSDK sharedSDK] currentSuperToken];
-    }
-    return nil;
+    return [[VungleSDK sharedSDK] currentSuperToken];
 }
 
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController


### PR DESCRIPTION
Our native SDK implements the feature  "Missing bid token on early ad requests - optimize availability of bid token"(ticket IOS-3535: https://vungle.atlassian.net/browse/IOS-3535). For MoPub Adapter, we also need to return the super token as early as possible.

IOS-3547