### PR TITLE
[IOS-3571]Adapter support for HBP changes (use of adMarkup when provided)

### DIFF
--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -42,11 +42,7 @@
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.adMarkup = adMarkup;
     self.options = nil;
-    if (adMarkup) {
-        NSData *data = [adMarkup dataUsingEncoding:NSUTF8StringEncoding];
-        id adMarkupDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-        self.eventId = [adMarkupDict objectForKey:kVungleAdEventId];
-    }
+    self.eventId = [[VungleRouter sharedRouter] parseEventId:adMarkup];
     
     NSString *format = [info objectForKey:@"adunit_format"];
     BOOL isMediumRectangleFormat = (format != nil ? [[format lowercaseString] containsString:@"medium_rectangle"] : NO);

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -5,7 +5,6 @@
 //  Copyright © 2019 MoPub. All rights reserved.
 //
 
-#import <VungleSDK/VungleSDK.h>
 #import "VungleBannerCustomEvent.h"
 #if __has_include("MoPub.h")
     #import "MPLogging.h"
@@ -16,6 +15,7 @@
 @interface VungleBannerCustomEvent () <VungleRouterDelegate>
 
 @property (nonatomic, copy) NSString *placementId;
+@property (nonatomic, copy) NSString *adMarkup;
 @property (nonatomic, copy) NSDictionary *options;
 @property (nonatomic, assign) NSDictionary *bannerInfo;
 @property (nonatomic, assign) NSTimer *timeOutTimer;
@@ -39,6 +39,7 @@
 - (void)requestAdWithSize:(CGSize)size adapterInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup
 {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
+    self.adMarkup = adMarkup;
     self.options = nil;
     
     NSString *format = [info objectForKey:@"adunit_format"];
@@ -61,10 +62,10 @@
     
     if (@available(iOS 10.0, *)) {
         self.timeOutTimer = [NSTimer scheduledTimerWithTimeInterval:BANNER_TIMEOUT_INTERVAL repeats:NO block:^(NSTimer * _Nonnull timer) {
-        if (!self.isAdCached) {
-            [[VungleRouter sharedRouter] clearDelegateForRequestingBanner];
-        }
-    }];
+            if (!self.isAdCached) {
+                [[VungleRouter sharedRouter] clearDelegateForRequestingBanner];
+            }
+        }];
     }
     
     MPLogAdEvent([MPLogEvent adLoadAttemptForAdapter:NSStringFromClass(self.class) dspCreativeId:nil dspName:nil], self.getPlacementID);
@@ -73,9 +74,7 @@
 
 - (void)dealloc
 {
-    if (self.bannerState == BannerRouterDelegateStatePlaying) {
-        [[VungleSDK sharedSDK] finishDisplayingAd:self.placementId];
-    }
+    [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId];
 }
 
 - (CGSize)sizeForCustomEventInfo:(CGSize)size
@@ -186,6 +185,11 @@
 - (NSString *)getPlacementID
 {
     return self.placementId;
+}
+
+- (NSString *)getAdMarkup
+{
+    return self.adMarkup;
 }
 
 - (CGSize)getBannerSize

--- a/Vungle/VungleBannerCustomEvent.m
+++ b/Vungle/VungleBannerCustomEvent.m
@@ -16,6 +16,7 @@
 
 @property (nonatomic, copy) NSString *placementId;
 @property (nonatomic, copy) NSString *adMarkup;
+@property (nonatomic, copy) NSString *eventId;
 @property (nonatomic, copy) NSDictionary *options;
 @property (nonatomic, assign) NSDictionary *bannerInfo;
 @property (nonatomic, assign) NSTimer *timeOutTimer;
@@ -41,6 +42,11 @@
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.adMarkup = adMarkup;
     self.options = nil;
+    if (adMarkup) {
+        NSData *data = [adMarkup dataUsingEncoding:NSUTF8StringEncoding];
+        id adMarkupDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        self.eventId = [adMarkupDict objectForKey:kVungleAdEventId];
+    }
     
     NSString *format = [info objectForKey:@"adunit_format"];
     BOOL isMediumRectangleFormat = (format != nil ? [[format lowercaseString] containsString:@"medium_rectangle"] : NO);
@@ -74,7 +80,7 @@
 
 - (void)dealloc
 {
-    [[VungleRouter sharedRouter] completeBannerAdViewForPlacementID:self.placementId];
+    [[VungleRouter sharedRouter] completeBannerAdViewForDelegate:self];
 }
 
 - (CGSize)sizeForCustomEventInfo:(CGSize)size
@@ -190,6 +196,11 @@
 - (NSString *)getAdMarkup
 {
     return self.adMarkup;
+}
+
+- (NSString *)getEventId
+{
+    return self.eventId;
 }
 
 - (CGSize)getBannerSize

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -5,7 +5,6 @@
 //  Copyright (c) 2013 MoPub. All rights reserved.
 //
 
-#import <VungleSDK/VungleSDK.h>
 #if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MoPub.h"
@@ -20,6 +19,7 @@
 
 @property (nonatomic) BOOL isAdLoaded;
 @property (nonatomic, copy) NSString *placementId;
+@property (nonatomic, copy) NSString *adMarkup;
 @property (nonatomic, copy) NSDictionary *options;
 
 @end
@@ -32,7 +32,7 @@
 #pragma mark - MPFullscreenAdAdapter Override
 
 - (BOOL)hasAdAvailable {
-    return [[VungleRouter sharedRouter] isAdAvailableForPlacementId:self.placementId];
+    return [[VungleRouter sharedRouter] isAdAvailableForDelegate:self];
 }
 
 - (BOOL)isRewardExpected {
@@ -47,6 +47,7 @@
 - (void)requestAdWithAdapterInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup
 {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
+    self.adMarkup = adMarkup;
     
     // Cache the initialization parameters
     [VungleAdapterConfiguration updateInitializationParameters:info];
@@ -57,7 +58,7 @@
 
 - (void)presentAdFromViewController:(UIViewController *)viewController
 {
-    if ([[VungleRouter sharedRouter] isAdAvailableForPlacementId:self.placementId]) {
+    if ([[VungleRouter sharedRouter] isAdAvailableForDelegate:self]) {
         
         if (self.options) {
             // In the event that options have been updated
@@ -96,7 +97,7 @@
         self.options = options.count ? options : nil;
         
         MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], self.placementId);
-        [[VungleRouter sharedRouter] presentInterstitialAdFromViewController:viewController options:self.options forPlacementId:self.placementId];
+        [[VungleRouter sharedRouter] presentInterstitialAdFromViewController:viewController options:self.options delegate:self];
     } else {
         NSError *error = [NSError errorWithCode:MOPUBErrorAdapterFailedToLoadAd localizedDescription:@"Failed to show Vungle video interstitial: Vungle now claims that there is no available video ad."];
         MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:error], [self getPlacementID]);
@@ -210,6 +211,11 @@
 - (NSString *)getPlacementID
 {
     return self.placementId;
+}
+
+- (NSString *)getAdMarkup
+{
+    return self.adMarkup;
 }
 
 @end

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -49,11 +49,7 @@
 {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.adMarkup = adMarkup;
-    if (adMarkup) {
-        NSData *data = [adMarkup dataUsingEncoding:NSUTF8StringEncoding];
-        id adMarkupDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-        self.eventId = [adMarkupDict objectForKey:kVungleAdEventId];
-    }
+    self.eventId = [[VungleRouter sharedRouter] parseEventId:adMarkup];
     
     // Cache the initialization parameters
     [VungleAdapterConfiguration updateInitializationParameters:info];

--- a/Vungle/VungleInterstitialCustomEvent.m
+++ b/Vungle/VungleInterstitialCustomEvent.m
@@ -20,6 +20,7 @@
 @property (nonatomic) BOOL isAdLoaded;
 @property (nonatomic, copy) NSString *placementId;
 @property (nonatomic, copy) NSString *adMarkup;
+@property (nonatomic, copy) NSString *eventId;
 @property (nonatomic, copy) NSDictionary *options;
 
 @end
@@ -48,6 +49,11 @@
 {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.adMarkup = adMarkup;
+    if (adMarkup) {
+        NSData *data = [adMarkup dataUsingEncoding:NSUTF8StringEncoding];
+        id adMarkupDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        self.eventId = [adMarkupDict objectForKey:kVungleAdEventId];
+    }
     
     // Cache the initialization parameters
     [VungleAdapterConfiguration updateInitializationParameters:info];
@@ -121,7 +127,7 @@
 
 - (void)cleanUp
 {
-    [[VungleRouter sharedRouter] clearDelegateForPlacementId:self.placementId];
+    [[VungleRouter sharedRouter] cleanupFullScreenDelegate:self];
 }
 
 #pragma mark - VungleRouterDelegate
@@ -216,6 +222,11 @@
 - (NSString *)getAdMarkup
 {
     return self.adMarkup;
+}
+
+- (NSString *)getEventId
+{
+    return self.eventId;
 }
 
 @end

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -56,11 +56,7 @@
 {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.adMarkup = adMarkup;
-    if (adMarkup) {
-        NSData *data = [adMarkup dataUsingEncoding:NSUTF8StringEncoding];
-        id adMarkupDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-        self.eventId = [adMarkupDict objectForKey:kVungleAdEventId];
-    }
+    self.eventId = [[VungleRouter sharedRouter] parseEventId:adMarkup];
 
     // Cache the initialization parameters
     [VungleAdapterConfiguration updateInitializationParameters:info];

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -5,7 +5,6 @@
 //  Copyright (c) 2015 MoPub. All rights reserved.
 //
 
-#import <VungleSDK/VungleSDK.h>
 #if __has_include("MoPub.h")
     #import "MPError.h"
     #import "MPLogging.h"
@@ -21,6 +20,7 @@
 @interface VungleRewardedVideoCustomEvent ()  <VungleRouterDelegate>
 
 @property (nonatomic, copy) NSString *placementId;
+@property (nonatomic, copy) NSString *adMarkup;
 @property (nonatomic) BOOL isAdLoaded;
 
 @end
@@ -43,7 +43,7 @@
 
 - (BOOL)hasAdAvailable
 {
-    return [[VungleSDK sharedSDK] isAdCachedForPlacementID:self.placementId];
+    return [[VungleRouter sharedRouter] isAdAvailableForDelegate:self];
 }
 
 - (BOOL)enableAutomaticImpressionAndClickTracking
@@ -54,6 +54,7 @@
 - (void)requestAdWithAdapterInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup
 {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
+    self.adMarkup = adMarkup;
 
     // Cache the initialization parameters
     [VungleAdapterConfiguration updateInitializationParameters:info];
@@ -65,13 +66,13 @@
 - (void)presentAdFromViewController:(UIViewController *)viewController
 {
     MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], self.placementId);
-    if ([[VungleRouter sharedRouter] isAdAvailableForPlacementId:self.placementId]) {
+    if ([[VungleRouter sharedRouter] isAdAvailableForDelegate:self]) {
         VungleInstanceMediationSettings *settings = [self.delegate fullscreenAdAdapter:self instanceMediationSettingsForClass:VungleInstanceMediationSettings.class];
 
         [[VungleRouter sharedRouter] presentRewardedVideoAdFromViewController:viewController
                                                                    customerId:[self.delegate customerIdForAdapter:self]
                                                                      settings:settings
-                                                               forPlacementId:self.placementId];
+                                                                     delegate:self];
     } else {
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:@{ NSLocalizedDescriptionKey: @"Failed to show Vungle rewarded video: Vungle now claims that there is no available video ad."}];
         MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:error], [self getPlacementID]);
@@ -173,6 +174,11 @@
 - (NSString *)getPlacementID
 {
     return self.placementId;
+}
+
+- (NSString *)getAdMarkup
+{
+    return self.adMarkup;
 }
 
 - (void)rewardUser

--- a/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/Vungle/VungleRewardedVideoCustomEvent.m
@@ -21,6 +21,7 @@
 
 @property (nonatomic, copy) NSString *placementId;
 @property (nonatomic, copy) NSString *adMarkup;
+@property (nonatomic, copy) NSString *eventId;
 @property (nonatomic) BOOL isAdLoaded;
 
 @end
@@ -55,6 +56,11 @@
 {
     self.placementId = [info objectForKey:kVunglePlacementIdKey];
     self.adMarkup = adMarkup;
+    if (adMarkup) {
+        NSData *data = [adMarkup dataUsingEncoding:NSUTF8StringEncoding];
+        id adMarkupDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        self.eventId = [adMarkupDict objectForKey:kVungleAdEventId];
+    }
 
     // Cache the initialization parameters
     [VungleAdapterConfiguration updateInitializationParameters:info];
@@ -82,7 +88,7 @@
 
 - (void)cleanUp
 {
-    [[VungleRouter sharedRouter] clearDelegateForPlacementId:self.placementId];
+    [[VungleRouter sharedRouter] cleanupFullScreenDelegate:self];
 }
 
 #pragma mark - MPVungleDelegate
@@ -179,6 +185,11 @@
 - (NSString *)getAdMarkup
 {
     return self.adMarkup;
+}
+
+- (NSString *)getEventId
+{
+    return self.eventId;
 }
 
 - (void)rewardUser

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -53,6 +53,7 @@ extern const CGSize kVNGLeaderboardBannerSize;
 - (VungleConsentStatus) getCurrentConsentStatus;
 - (void)cleanupFullScreenDelegate:(id<VungleRouterDelegate>)delegate;
 - (void)clearDelegateForRequestingBanner;
+- (NSString *)parseEventId:(NSString *)adMarkup;
 
 @end
 

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -38,15 +38,16 @@ extern const CGSize kVNGLeaderboardBannerSize;
 - (void)requestInterstitialAdWithCustomEventInfo:(NSDictionary *)info delegate:(id<VungleRouterDelegate>)delegate;
 - (void)requestRewardedVideoAdWithCustomEventInfo:(NSDictionary *)info delegate:(id<VungleRouterDelegate>)delegate;
 - (void)requestBannerAdWithCustomEventInfo:(NSDictionary *)info size:(CGSize)size delegate:(id<VungleRouterDelegate>)delegate;
-- (BOOL)isAdAvailableForPlacementId:(NSString *)placementId;
+- (BOOL)isAdAvailableForDelegate:(id<VungleRouterDelegate>)delegate;
 - (NSString *)currentSuperToken;
-- (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options forPlacementId:(NSString *)placementId;
-- (void)presentRewardedVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId settings:(VungleInstanceMediationSettings *)settings forPlacementId:(NSString *)placementId;
+- (void)presentInterstitialAdFromViewController:(UIViewController *)viewController options:(NSDictionary *)options delegate:(id<VungleRouterDelegate>)delegate;
+- (void)presentRewardedVideoAdFromViewController:(UIViewController *)viewController customerId:(NSString *)customerId settings:(VungleInstanceMediationSettings *)settings delegate:(id<VungleRouterDelegate>)delegate;
 - (UIView *)renderBannerAdInView:(UIView *)bannerView
                         delegate:(id<VungleRouterDelegate>)delegate
                          options:(NSDictionary *)options
                   forPlacementID:(NSString *)placementID
                             size:(CGSize)size;
+- (void)completeBannerAdViewForPlacementID:(NSString *)placementID;
 - (void)updateConsentStatus:(VungleConsentStatus)status;
 - (VungleConsentStatus) getCurrentConsentStatus;
 - (void)clearDelegateForPlacementId:(NSString *)placementId;
@@ -76,6 +77,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)vungleAdDidFailToPlay:(NSError *)error;
 - (void)vungleAdDidFailToLoad:(NSError *)error;
 - (NSString *)getPlacementID;
+- (NSString *)getAdMarkup;
 
 @optional
 

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <VungleSDK/VungleSDKHeaderBidding.h>
 #import <VungleSDK/VungleSDK.h>
 #import <VungleSDK/VungleSDKNativeAds.h>
 
@@ -29,7 +30,7 @@ extern const CGSize kVNGLeaderboardBannerSize;
 @protocol VungleRouterDelegate;
 @class VungleInstanceMediationSettings;
 
-@interface VungleRouter : NSObject <VungleSDKDelegate, VungleSDKNativeAds>
+@interface VungleRouter : NSObject <VungleSDKDelegate, VungleSDKNativeAds, VungleSDKHBDelegate>
 
 + (VungleRouter *)sharedRouter;
 

--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -19,6 +19,7 @@ extern NSString *const kVungleSDKCollectDevice;
 extern NSString *const kVungleSDKMinSpaceForInit;
 extern NSString *const kVungleSDKMinSpaceForAdRequest;
 extern NSString *const kVungleSDKMinSpaceForAssetLoad;
+extern NSString *const kVungleAdEventId;
 
 extern const CGSize kVNGMRECSize;
 extern const CGSize kVNGBannerSize;
@@ -47,10 +48,10 @@ extern const CGSize kVNGLeaderboardBannerSize;
                          options:(NSDictionary *)options
                   forPlacementID:(NSString *)placementID
                             size:(CGSize)size;
-- (void)completeBannerAdViewForPlacementID:(NSString *)placementID;
+- (void)completeBannerAdViewForDelegate:(id<VungleRouterDelegate>)delegate;
 - (void)updateConsentStatus:(VungleConsentStatus)status;
 - (VungleConsentStatus) getCurrentConsentStatus;
-- (void)clearDelegateForPlacementId:(NSString *)placementId;
+- (void)cleanupFullScreenDelegate:(id<VungleRouterDelegate>)delegate;
 - (void)clearDelegateForRequestingBanner;
 
 @end
@@ -78,6 +79,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 - (void)vungleAdDidFailToLoad:(NSError *)error;
 - (NSString *)getPlacementID;
 - (NSString *)getAdMarkup;
+- (NSString *)getEventId;
 
 @optional
 

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -310,7 +310,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
             }
         }
         
-        if ([self isBannerAdAvailableForPlacementId:placementID size:size delegate:delegate]) {
+        if ([self isBannerAdAvailableForDelegate:delegate]) {
             MPLogInfo(@"Vungle: Banner ad already cached for Placement ID :%@", placementID);
             delegate.bannerState = BannerRouterDelegateStateCached;
             [delegate vungleAdDidLoad];
@@ -344,13 +344,16 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     return [[VungleSDK sharedSDK] isAdCachedForPlacementID:[delegate getPlacementID] adMarkup:[delegate getAdMarkup]];
 }
 
-- (BOOL)isBannerAdAvailableForPlacementId:(NSString *)placementId size:(CGSize)size delegate:(id<VungleRouterDelegate>)delegate
+- (BOOL)isBannerAdAvailableForDelegate:(id<VungleRouterDelegate>)delegate
 {
+    CGSize size = [delegate getBannerSize];
+    NSString *placementId = [delegate getPlacementID];
+    NSString *adMarkup = [delegate getAdMarkup];
     if (CGSizeEqualToSize(size, kVNGMRECSize)) {
-        return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementId adMarkup:[delegate getAdMarkup]];
+        return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementId adMarkup:adMarkup];
     }
 
-    return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementId adMarkup:[delegate getAdMarkup]
+    return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementId adMarkup:adMarkup
                                                   withSize:[self getVungleBannerAdSizeType:size]];
 }
 
@@ -432,7 +435,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 {
     NSError *bannerError = nil;
     
-    if ([self isBannerAdAvailableForPlacementId:placementID size:size delegate:delegate]) {
+    if ([self isBannerAdAvailableForDelegate:delegate]) {
         BOOL success = [[VungleSDK sharedSDK] addAdViewToView:bannerView withOptions:options placementID:placementID adMarkup:[delegate getAdMarkup] error:&bannerError];
         
         if (success) {

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -587,7 +587,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
             CGSize size = [delegateInstance getBannerSize];
             [self requestBannerAdWithPlacementID:placementId size:size delegate:delegateInstance];
         } else {
-            [self requestAdWithCustomEventInfo:info delegate:delegateInstance];
+            [self requestAdWithCustomEventInfo:nil delegate:delegateInstance];
         }
     }
 

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -807,16 +807,16 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)vungleDidShowAdForPlacementID:(nullable NSString *)placementID
 {
-    [self vungleDidShowAdForPlacementID:placementID eventId:nil];
+    [self vungleDidShowAdForPlacementID:placementID eventID:nil];
 }
 
 - (void)vungleDidShowAdForEventID:(nullable NSString *)eventID
 {
-    [self vungleDidShowAdForPlacementID:nil eventId:eventID];
+    [self vungleDidShowAdForPlacementID:nil eventID:eventID];
 }
 
 - (void)vungleDidShowAdForPlacementID:(NSString *)placementID
-                              eventId:(NSString*)eventID
+                              eventID:(NSString *)eventID
 {
     id<VungleRouterDelegate> targetDelegate = [self getFullScreenDelegateWithPlacement:placementID eventID:eventID];
     if ([targetDelegate respondsToSelector:@selector(vungleAdDidAppear)]) {
@@ -918,7 +918,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     if (!placementID.length) {
         return;
     }
-    [self vungleTrackClickForPlacementID:placementID eventId:nil];
+    [self vungleTrackClickForPlacementID:placementID eventID:nil];
 }
 
 - (void)vungleTrackClickForEventID:(nullable NSString *)eventID
@@ -926,11 +926,11 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     if (!eventID.length) {
         return;
     }
-    [self vungleTrackClickForPlacementID:nil eventId:eventID];
+    [self vungleTrackClickForPlacementID:nil eventID:eventID];
 }
 
 - (void)vungleTrackClickForPlacementID:(NSString *)placementID
-                               eventId:(NSString *)eventID
+                               eventID:(NSString *)eventID
 {
     id<VungleRouterDelegate> targetDelegate = [self getDelegateWithPlacement:placementID
                                                                      eventID:eventID

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -642,11 +642,11 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 - (id<VungleRouterDelegate>)getFullScreenDelegateWithPlacement:(NSString *)placementID
                                                        eventID:(NSString *)eventID
 {
-    if (placementID.length) {
-        return [self.delegatesDict objectForKey:placementID];
-    }
     if (eventID.length > 0) {
         return [self.hbDelegatesDict objectForKey:eventID];
+    }
+    if (placementID.length) {
+        return [self.delegatesDict objectForKey:placementID];
     }
     return nil;
 }
@@ -654,11 +654,11 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 - (id<VungleRouterDelegate>)getBannerDelegateWithPlacement:(NSString *)placementID
                                                    eventID:(NSString *)eventID
 {
-    if (placementID.length) {
-        return [self.bannerDelegates objectForKey:placementID];
-    }
     if (eventID.length > 0) {
         return [self.hbBannerDelegates objectForKey:eventID];
+    }
+    if (placementID.length) {
+        return [self.bannerDelegates objectForKey:placementID];
     }
     return nil;
 }

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -541,10 +541,12 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 - (void)removeDelegatesIfContainsPlacement:(NSString *)placementID
                                 dictionary:(NSMutableDictionary *)dictionary
 {
-    NSArray *array = [dictionary.keyEnumerator allObjects];
-    for (NSString *key in array) {
-        if ([key containsString:placementID]) {
-            [dictionary removeObjectForKey:key];
+    @synchronized (self) {
+        NSArray *array = [dictionary.keyEnumerator allObjects];
+        for (NSString *key in array) {
+            if ([key containsString:placementID]) {
+                [dictionary removeObjectForKey:key];
+            }
         }
     }
 }
@@ -552,10 +554,12 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 - (void)removeDelegatesIfContainsPlacement:(NSString *)placementID
                                      table:(NSMapTable *)table
 {
-    NSArray *array = [table.keyEnumerator allObjects];
-    for (NSString *key in array) {
-        if ([key containsString:placementID]) {
-            [table removeObjectForKey:key];
+    @synchronized (self) {
+        NSArray *array = [table.keyEnumerator allObjects];
+        for (NSString *key in array) {
+            if ([key containsString:placementID]) {
+                [table removeObjectForKey:key];
+            }
         }
     }
 }

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -538,6 +538,28 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     }
 }
 
+- (void)removeDelegatesIfContainsPlacement:(NSString *)placementID
+                                dictionary:(NSMutableDictionary *)dictionary
+{
+    NSArray *array = [dictionary.keyEnumerator allObjects];
+    for (NSString *key in array) {
+        if ([key containsString:placementID]) {
+            [dictionary removeObjectForKey:key];
+        }
+    }
+}
+
+- (void)removeDelegatesIfContainsPlacement:(NSString *)placementID
+                                     table:(NSMapTable *)table
+{
+    NSArray *array = [table.keyEnumerator allObjects];
+    for (NSString *key in array) {
+        if ([key containsString:placementID]) {
+            [table removeObjectForKey:key];
+        }
+    }
+}
+
 - (void)addToWaitingListWithDelegate:(id<VungleRouterDelegate>)delegate
 {
     NSString *key = [self getKeyFromDelegate:delegate];
@@ -550,7 +572,6 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 {
     for (id key in self.waitingListDict) {
         id<VungleRouterDelegate> delegateInstance = [self.waitingListDict objectForKey:key];
-        
         if ([delegateInstance respondsToSelector:@selector(getBannerSize)]) {
             [self requestBannerAdWithDelegate:delegateInstance];
         } else {
@@ -897,6 +918,9 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)vungleDidShowAdForEventID:(nullable NSString *)eventID
 {
+    if (!eventID.length) {
+        return;
+    }
     [self vungleDidShowAdForPlacementID:nil eventID:eventID];
 }
 
@@ -910,6 +934,9 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)vungleWillCloseAdForEventID:(nonnull NSString *)eventID
 {
+    if (!eventID.length) {
+        return;
+    }
     [self vungleWillCloseAdForPlacementID:nil eventID:eventID];
 }
 
@@ -931,12 +958,28 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)vungleRewardUserForEventID:(nullable NSString *)eventID
 {
+    if (!eventID.length) {
+        return;
+    }
     [self vungleRewardUserForPlacementID:nil eventID:eventID];
 }
 
 - (void)vungleWillLeaveApplicationForEventID:(nullable NSString *)eventID
 {
+    if (!eventID.length) {
+        return;
+    }
     [self vungleWillLeaveApplicationForPlacementID:nil eventID:eventID];
+}
+
+- (void)invalidateObjectsForPlacementID:(nullable NSString *)placementID
+{
+    if (!placementID.length) {
+        return;
+    }
+    [self removeDelegatesIfContainsPlacement:placementID dictionary:self.waitingListDict];
+    [self removeDelegatesIfContainsPlacement:placementID table:self.delegatesDict];
+    [self removeDelegatesIfContainsPlacement:placementID table:self.bannerDelegates];
 }
 
 #pragma mark - VungleSDKNativeAds delegate methods

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -829,7 +829,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     if (!placementID.length) {
         return;
     }
-    [self vungleAdViewedForPlacement:placementID eventId:nil];
+    [self vungleAdViewedForPlacement:placementID eventID:nil];
 }
 
 - (void)vungleAdViewedForAdUnit:(nullable NSString *)eventID
@@ -837,11 +837,11 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     if (!eventID.length) {
         return;
     }
-    [self vungleAdViewedForPlacement:nil eventId:eventID];
+    [self vungleAdViewedForPlacement:nil eventID:eventID];
 }
 
 - (void)vungleAdViewedForPlacement:(NSString *)placementID
-                           eventId:(NSString*)eventID
+                           eventID:(NSString *)eventID
 {
     id<VungleRouterDelegate> targetDelegate = [self getFullScreenDelegateWithPlacement:placementID eventID:eventID];
     if (!targetDelegate) {
@@ -857,16 +857,16 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)vungleWillCloseAdForPlacementID:(nonnull NSString *)placementID
 {
-    [self vungleWillCloseAdForPlacementID:placementID eventId:nil];
+    [self vungleWillCloseAdForPlacementID:placementID eventID:nil];
 }
 
 - (void)vungleWillCloseAdForEventID:(nonnull NSString *)eventID
 {
-    [self vungleWillCloseAdForPlacementID:nil eventId:eventID];
+    [self vungleWillCloseAdForPlacementID:nil eventID:eventID];
 }
 
 - (void)vungleWillCloseAdForPlacementID:(NSString *)placementID
-                                eventId:(NSString*)eventID
+                                eventID:(NSString *)eventID
 {
     id<VungleRouterDelegate> targetDelegate = [self getFullScreenDelegateWithPlacement:placementID eventID:eventID];
     if ([targetDelegate respondsToSelector:@selector(vungleAdWillDisappear)]) {
@@ -880,7 +880,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     if (!placementID.length) {
         return;
     }
-    [self vungleDidCloseAdForPlacementID:placementID eventId:nil];
+    [self vungleDidCloseAdForPlacementID:placementID eventID:nil];
 }
 
 - (void)vungleDidCloseAdForEventID:(nonnull NSString *)eventID
@@ -888,11 +888,11 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     if (!eventID.length) {
         return;
     }
-    [self vungleDidCloseAdForPlacementID:nil eventId:eventID];
+    [self vungleDidCloseAdForPlacementID:nil eventID:eventID];
 }
 
 - (void)vungleDidCloseAdForPlacementID:(NSString *)placementID
-                               eventId:(NSString*)eventID
+                               eventID:(NSString *)eventID
 {
     id<VungleRouterDelegate> targetDelegate = [self getFullScreenDelegateWithPlacement:placementID eventID:eventID];
     if (!targetDelegate) {
@@ -940,16 +940,16 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)vungleRewardUserForPlacementID:(nullable NSString *)placementID
 {
-    [self vungleRewardUserForPlacementID:placementID eventId:nil];
+    [self vungleRewardUserForPlacementID:placementID eventID:nil];
 }
 
 - (void)vungleRewardUserForEventID:(nullable NSString *)eventID
 {
-    [self vungleRewardUserForPlacementID:nil eventId:eventID];
+    [self vungleRewardUserForPlacementID:nil eventID:eventID];
 }
 
 - (void)vungleRewardUserForPlacementID:(NSString *)placementID
-                               eventId:(NSString*)eventID
+                               eventID:(NSString *)eventID
 {
     id<VungleRouterDelegate> targetDelegate = [self getFullScreenDelegateWithPlacement:placementID eventID:eventID];
     if ([targetDelegate respondsToSelector:@selector(vungleAdRewardUser)]) {
@@ -959,16 +959,16 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 
 - (void)vungleWillLeaveApplicationForPlacementID:(nullable NSString *)placementID
 {
-    [self vungleWillLeaveApplicationForPlacementID:placementID eventId:nil];
+    [self vungleWillLeaveApplicationForPlacementID:placementID eventID:nil];
 }
 
 - (void)vungleWillLeaveApplicationForEventID:(nullable NSString *)eventID
 {
-    [self vungleWillLeaveApplicationForPlacementID:nil eventId:eventID];
+    [self vungleWillLeaveApplicationForPlacementID:nil eventID:eventID];
 }
 
 - (void)vungleWillLeaveApplicationForPlacementID:(NSString *)placementID
-                                         eventId:(NSString*)eventID
+                                         eventID:(NSString *)eventID
 {
     id<VungleRouterDelegate> targetDelegate = [self getDelegateWithPlacement:placementID
                                                                      eventID:eventID


### PR DESCRIPTION
In the MoPub adapter, the ad markup is passed from the custom event delegates to the router then to the native SDK. The event delegate is stored into a separate dictionary / hash table for tracking header bidding delegates, in case there are multiple ads per placement. The native SDK will perform its functions and make the callback to the adapter with the event id.

https://vungle.atlassian.net/browse/IOS-3571
https://vungle.atlassian.net/browse/IOS-3623

IOS-3571
IOS-3623