### PR TITLE
[IOS-3732] Fixing banner refresh issue found during e2e testing

### DIFF
--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -414,7 +414,8 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         BOOL success = [[VungleSDK sharedSDK] addAdViewToView:bannerView withOptions:options placementID:placementID adMarkup:[delegate getAdMarkup] error:&bannerError];
         
         if (success) {
-            [self completeBannerAdViewForDelegate:delegate];
+            [self completeOldBannerAdViewForDelegate:delegate];
+            MPLogInfo(@"Vungle: Rendering a Banner ad for %@ eventID %@", placementID, [delegate getEventId]);
             // For a refresh banner delegate, if the Banner view is constructed successfully,
             // it will replace the old banner delegate.
             [self replaceOldBannerDelegateWithDelegate:delegate];
@@ -428,20 +429,35 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     return nil;
 }
 
+- (void)completeOldBannerAdViewForDelegate:(id<VungleRouterDelegate>)newDelegate
+{
+    @synchronized (self) {
+        NSString *placementID = [newDelegate getPlacementID];
+        id<VungleRouterDelegate> oldDelegate;
+        for(NSString *key in self.bannerDelegates) {
+            oldDelegate = [self.bannerDelegates objectForKey:key];
+            if ([key containsString:placementID] && [oldDelegate bannerState] == BannerRouterDelegateStatePlaying) {
+                BOOL isHeaderBidding = [newDelegate getEventId] || [oldDelegate getEventId];
+                if (isHeaderBidding && [oldDelegate getEventId] == [newDelegate getEventId]) {
+                    continue;
+                }
+                MPLogInfo(@"Vungle: Triggering a Banner ad completion call in refresh for %@ eventID: %@", placementID, [oldDelegate getEventId]);
+                [[VungleSDK sharedSDK] finishDisplayingAd:placementID adMarkup:[oldDelegate getAdMarkup]];
+                oldDelegate.bannerState = BannerRouterDelegateStateClosing;
+            }
+        }
+        [self.bannerDelegates removeObjectForKey:[self getKeyFromDelegate:oldDelegate]];
+    }
+}
+
 - (void)completeBannerAdViewForDelegate:(id<VungleRouterDelegate>)delegate
 {
     @synchronized (self) {
-        NSString *placementID = [delegate getPlacementID];
-        if (placementID.length > 0) {
-            MPLogInfo(@"Vungle: Triggering a Banner ad completion call for %@", placementID);
-            id<VungleRouterDelegate> bannerDelegate =
-            [self getBannerDelegateWithPlacement:placementID
-                                         eventID:[delegate getEventId]
-                                 withBannerState:BannerRouterDelegateStatePlaying];
-            if (bannerDelegate) {
-                [[VungleSDK sharedSDK] finishDisplayingAd:placementID adMarkup:[bannerDelegate getAdMarkup]];
-                bannerDelegate.bannerState = BannerRouterDelegateStateClosing;
-            }
+        if ([delegate bannerState] == BannerRouterDelegateStatePlaying) {
+            MPLogInfo(@"Vungle: Triggering a Banner ad completion call in dealloc for %@ eventID: %@", [delegate getPlacementID], [delegate getEventId]);
+            [[VungleSDK sharedSDK] finishDisplayingAd:[delegate getPlacementID] adMarkup:[delegate getAdMarkup]];
+            delegate.bannerState = BannerRouterDelegateStateClosing;
+            [self.bannerDelegates removeObjectForKey:[self getKeyFromDelegate:delegate]];
         }
     }
 }

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -434,8 +434,9 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     @synchronized (self) {
         NSString *placementID = [newDelegate getPlacementID];
         id<VungleRouterDelegate> oldDelegate;
-        for(NSString *key in self.bannerDelegates) {
-            oldDelegate = [self.bannerDelegates objectForKey:key];
+        NSMapTable<NSString *, id<VungleRouterDelegate>> *bannerDelegatesCopy = [self.bannerDelegates mutableCopy];
+        for(NSString *key in bannerDelegatesCopy) {
+            oldDelegate = [bannerDelegatesCopy objectForKey:key];
             if ([key containsString:placementID] && [oldDelegate bannerState] == BannerRouterDelegateStatePlaying) {
                 BOOL isHeaderBidding = [newDelegate getEventId] || [oldDelegate getEventId];
                 if (isHeaderBidding && [oldDelegate getEventId] == [newDelegate getEventId]) {
@@ -444,9 +445,9 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                 MPLogInfo(@"Vungle: Triggering a Banner ad completion call in refresh for %@ eventID: %@", placementID, [oldDelegate getEventId]);
                 [[VungleSDK sharedSDK] finishDisplayingAd:placementID adMarkup:[oldDelegate getAdMarkup]];
                 oldDelegate.bannerState = BannerRouterDelegateStateClosing;
+                [self.bannerDelegates removeObjectForKey:[self getKeyFromDelegate:oldDelegate]];
             }
         }
-        [self.bannerDelegates removeObjectForKey:[self getKeyFromDelegate:oldDelegate]];
     }
 }
 


### PR DESCRIPTION
The issue was that the refresh for header bidding would trigger the delegate cleanup on the old delegate and after removal, the dealloc would trigger the delegate cleanup again for the currently playing banner. There was also the issue where the wrong delegate may be closed during refresh if header bidding was enabled.