### PR TITLE
[IOS-3775]Remove header bridging file for Swift project

### DIFF
--- a/Vungle/VungleRouter.h
+++ b/Vungle/VungleRouter.h
@@ -7,8 +7,6 @@
 
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-#import <VungleSDK/VungleSDK.h>
-#import <VungleSDK/VungleSDKNativeAds.h>
 
 extern NSString *const kVungleAppIdKey;
 extern NSString *const kVunglePlacementIdKey;
@@ -28,8 +26,9 @@ extern const CGSize kVNGLeaderboardBannerSize;
 
 @protocol VungleRouterDelegate;
 @class VungleInstanceMediationSettings;
+typedef NS_ENUM(NSInteger, VungleConsentStatus);
 
-@interface VungleRouter : NSObject <VungleSDKDelegate, VungleSDKNativeAds>
+@interface VungleRouter : NSObject
 
 + (VungleRouter *)sharedRouter;
 

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -5,7 +5,9 @@
 //  Copyright (c) 2015 MoPub. All rights reserved.
 //
 
+#import <VungleSDK/VungleSDK.h>
 #import <VungleSDK/VungleSDKHeaderBidding.h>
+#import <VungleSDK/VungleSDKNativeAds.h>
 #if __has_include("MoPub.h")
     #import "MPLogging.h"
     #import "MPRewardedVideo.h"
@@ -39,7 +41,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     SDKInitializeStateInitialized
 };
 
-@interface VungleRouter ()
+@interface VungleRouter () <VungleSDKDelegate, VungleSDKNativeAds>
 
 @property (nonatomic, copy) NSString *vungleAppID;
 @property (nonatomic) BOOL isAdPlaying;


### PR DESCRIPTION
This PR is about removing header-bridging file when integrating with Swift project


IOS-3775