### PR TITLE
[IOS-3808]Enable background downloading by default

### DIFF
--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -131,6 +131,8 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
             NSError * error = nil;
             // Disable refresh functionality for all banners
             [[VungleSDK sharedSDK] disableBannerRefresh];
+            // Enable background downloading
+            [VungleSDK enableBackgroundDownload:YES];
             BOOL started = [[VungleSDK sharedSDK] startWithAppId:appId options:initOptions error:&error];
             if (!started && error.code == VungleSDKErrorSDKAlreadyInitializing) {
                 MPLogInfo(@"Vungle:SDK already has been initialized.");


### PR DESCRIPTION
This PR is enabling background downloading by default in 6.9.1.0 MoPub Adapter.

IOS-3808