### PR TITLE
[IOS-4033] Updating the check to only block calling the load fail if the playing ad is the one receiving the playability NO callback.

### DIFF
--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -782,8 +782,8 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
             // The SDK will fire playability updates during a successful playback
             // to relay the status. We don't want to trigger the fail load if it
             // is successfully playing. But don't block other placement load fails
-            if ([[self.playingFullScreenAdDelegate getPlacementID] isEqualToString:placementID] &&
-                [[self.playingFullScreenAdDelegate getAdMarkup] isEqualToString:adMarkup]) {
+            if (!([[self.playingFullScreenAdDelegate getPlacementID] isEqualToString:placementID] &&
+                [[self.playingFullScreenAdDelegate getAdMarkup] isEqualToString:adMarkup])) {
                 [targetDelegate vungleAdDidFailToLoad:playabilityError];
             }
         }

--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
 @interface VungleRouter () <VungleSDKDelegate, VungleSDKNativeAds, VungleSDKHBDelegate>
 
 @property (nonatomic, copy) NSString *vungleAppID;
-@property (nonatomic) BOOL isAdPlaying;
+@property (nonatomic) id<VungleRouterDelegate> playingFullScreenAdDelegate;
 @property (nonatomic) SDKInitializeState sdkInitializeState;
 
 @property (nonatomic) NSMutableDictionary *waitingListDict;
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         self.waitingListDict = [NSMutableDictionary dictionary];
         self.bannerDelegates = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsStrongMemory
                                                      valueOptions:NSPointerFunctionsWeakMemory];
-        self.isAdPlaying = NO;
+        self.playingFullScreenAdDelegate = nil;
     }
     return self;
 }
@@ -340,13 +340,13 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                                        delegate:(id<VungleRouterDelegate>)delegate
 {
     NSString *placementId = [delegate getPlacementID];
-    if (!self.isAdPlaying && [self isAdAvailableForDelegate:delegate]) {
-        self.isAdPlaying = YES;
+    if (!self.playingFullScreenAdDelegate && [self isAdAvailableForDelegate:delegate]) {
+        self.playingFullScreenAdDelegate = delegate;
         NSError *error = nil;
         BOOL success = [[VungleSDK sharedSDK] playAd:viewController options:options placementID:placementId adMarkup:[delegate getAdMarkup] error:&error];
         if (!success) {
             [delegate vungleAdDidFailToPlay:error ?: [NSError errorWithCode:MOPUBErrorVideoPlayerFailedToPlay localizedDescription:@"Failed to play Vungle Interstitial Ad."]];
-            self.isAdPlaying = NO;
+            self.playingFullScreenAdDelegate = nil;
         }
     } else {
         [delegate vungleAdDidFailToPlay:nil];
@@ -359,8 +359,8 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                                         delegate:(id<VungleRouterDelegate>)delegate
 {
     NSString *placementId = [delegate getPlacementID];
-    if (!self.isAdPlaying && [self isAdAvailableForDelegate:delegate]) {
-        self.isAdPlaying = YES;
+    if (!self.playingFullScreenAdDelegate && [self isAdAvailableForDelegate:delegate]) {
+        self.playingFullScreenAdDelegate = delegate;
         NSMutableDictionary *options = [NSMutableDictionary dictionary];
         if (customerId.length > 0) {
             options[VunglePlayAdOptionKeyUser] = customerId;
@@ -393,7 +393,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
         
         if (!success) {
             [delegate vungleAdDidFailToPlay:error ?: [NSError errorWithCode:MOPUBErrorVideoPlayerFailedToPlay localizedDescription:@"Failed to play Vungle Rewarded Video Ad."]];
-            self.isAdPlaying = NO;
+            self.playingFullScreenAdDelegate = nil;
         }
     } else {
         NSError *error = [NSError errorWithDomain:MoPubRewardedAdsSDKDomain code:MPRewardedAdErrorNoAdsAvailable userInfo:nil];
@@ -519,9 +519,8 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                     delegate:(id<VungleRouterDelegate>)delegate
 {
     NSString *key = [self getKeyFromDelegate:delegate];
-    if (![table objectForKey:key]) {
-        [table setObject:delegate forKey:key];
-    }
+    // Always set the latest delegate to be tracked
+    [table setObject:delegate forKey:key];
 }
 
 - (void)clearBannerDelegateWithState:(BannerRouterDelegateState)state
@@ -778,7 +777,12 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
             [targetDelegate vungleAdDidLoad];
         } else {
             MPLogInfo(@"%@", message);
-            if (!self.isAdPlaying) {
+            // Ignore any playability update if the delegate is the playing ad
+            // The SDK will fire playability updates during a successful playback
+            // to relay the status. We don't want to trigger the fail load if it
+            // is successfully playing. But don't block other placement load fails
+            if ([self.playingFullScreenAdDelegate getPlacementID] != placementID &&
+                [self.playingFullScreenAdDelegate getAdMarkup] != adMarkup) {
                 [targetDelegate vungleAdDidFailToLoad:playabilityError];
             }
         }
@@ -855,7 +859,7 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
     id<VungleRouterDelegate> targetDelegate = [self getFullScreenDelegateWithPlacement:placementID adMarkup:adMarkup];
     if ([targetDelegate respondsToSelector:@selector(vungleAdWillDisappear)]) {
         [targetDelegate vungleAdWillDisappear];
-        self.isAdPlaying = NO;
+        self.playingFullScreenAdDelegate = nil;
     }
 }
 


### PR DESCRIPTION
Updating the property tracking if a full screen ad is being played to the actual delegate. This is to prevent blocking any load fail callbacks if the publisher decides to load a different ad unit while playing a full screen ad.

IOS-4033

Tested on iOS Simulator.

1. Call load for a rewarded placement.
2. Call play for the rewarded placement and programmatically call load for the interstitial placement.
3. In the playability callback, force the isAdPlayable value to be NO for the interstitial placement.
    - I had to alter the interstitial custom event to directly firing the callback because it was auto-cached.
