### PR TITLE
[IOS-4132] Re-adding the check to track the delegate or not.

### DIFF
--- a/Vungle/VungleRouter.m
+++ b/Vungle/VungleRouter.m
@@ -546,8 +546,9 @@ typedef NS_ENUM(NSUInteger, SDKInitializeState) {
                     delegate:(id<VungleRouterDelegate>)delegate
 {
     NSString *key = [self getKeyFromDelegate:delegate];
-    // Always set the latest delegate to be tracked
-    [table setObject:delegate forKey:key];
+    if (![table objectForKey:key]) {
+        [table setObject:delegate forKey:key];
+    }
 }
 
 - (void)clearBannerDelegateWithState:(BannerRouterDelegateState)state


### PR DESCRIPTION
Re-adding the check to track the delegate or not.

IOS-4132

It turns out that this check is important for banner refreshes. If this check is not present, then the banner custom event will trigger the `finishedDisplayingAd` through the dealloc and cause 2 report_ad calls to be fired for some reason, even though there is only 1 call. If it is present, it prevents the `finishedDisplayingAd` from being fired in the dealloc and it will be fired during the rendering of the next banner ad on refresh.

This issue is not present when testing on the iOS Simulator for both cases, but on a iPhone device, the double report_ad can be seen. Unknown why the dealloc would cause the report_ad to be fired twice.

Tested on iPhone 8 Plus 14.5